### PR TITLE
Task/02-flyway-migrations

### DIFF
--- a/backend/bin/main/application-local.yml
+++ b/backend/bin/main/application-local.yml
@@ -1,0 +1,32 @@
+# Local development overrides — these values match the docker-compose.yml service config.
+# Never commit real secrets here. This file is safe to commit because it only
+# contains values for local Docker infrastructure.
+
+spring:
+  datasource:
+    url: jdbc:postgresql://localhost:5434/payment_db
+    username: payment_user
+    password: payment_pass
+
+  data:
+    redis:
+      host: 127.0.0.1
+      port: 6379
+      password: ""
+  # Explicit Redisson config — bypasses auto-config issues on Windows/WSL2 where
+  # Docker only binds Redis to IPv6 (::1), but Java resolves localhost → 127.0.0.1 (IPv4).
+  # Property prefix 'spring.redis.redisson' is read by RedissonProperties.java in the starter.
+  redis:
+    redisson:
+      file: classpath:redisson-local.yaml
+
+  kafka:
+    bootstrap-servers: localhost:9092
+
+# More verbose logging in local dev
+logging:
+  level:
+    dev.cuong.payment: DEBUG
+    org.springframework.security: DEBUG
+    org.hibernate.SQL: DEBUG
+    org.hibernate.type.descriptor.sql: TRACE   # log query parameter values

--- a/backend/bin/main/application.yml
+++ b/backend/bin/main/application.yml
@@ -1,0 +1,136 @@
+spring:
+  application:
+    name: payment-transaction-service
+
+  datasource:
+    url: ${DB_URL:jdbc:postgresql://localhost:5434/payment_db}
+    username: ${DB_USERNAME:payment_user}
+    password: ${DB_PASSWORD:payment_pass}
+    hikari:
+      maximum-pool-size: 20
+      minimum-idle: 5
+      connection-timeout: 30000   # 30s — fail fast if pool exhausted
+      idle-timeout: 600000        # 10min
+      max-lifetime: 1800000       # 30min — recycle connections before DB kills them
+
+  jpa:
+    hibernate:
+      ddl-auto: validate          # NEVER use create/update in production; Flyway owns the schema
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+        format_sql: false
+        jdbc:
+          batch_size: 25          # batch inserts for audit log writes
+          order_inserts: true
+    open-in-view: false           # prevent lazy-loading across HTTP request boundary
+
+  flyway:
+    enabled: true
+    validate-on-migrate: true
+    locations: classpath:db/migration
+    baseline-on-migrate: false
+
+  data:
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
+      password: ${REDIS_PASSWORD:}
+      timeout: 2000               # 2s connection timeout — fail fast
+
+  kafka:
+    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+      acks: all                   # wait for all in-sync replicas — durability guarantee
+      retries: 3
+      properties:
+        enable.idempotence: true              # Kafka-level exactly-once delivery to broker
+        max.in.flight.requests.per.connection: 5
+    consumer:
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
+      auto-offset-reset: earliest
+      enable-auto-commit: false             # manual commit — we commit only after processing succeeds
+      properties:
+        spring.json.trusted.packages: "dev.cuong.payment.*"
+        isolation.level: read_committed      # don't read uncommitted producer batches
+
+server:
+  port: ${SERVER_PORT:8080}
+  shutdown: graceful              # allow in-flight requests to complete before shutdown
+
+spring.lifecycle:
+  timeout-per-shutdown-phase: 30s
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,prometheus,metrics,circuitbreakers
+  endpoint:
+    health:
+      show-details: when-authorized
+      show-components: when-authorized
+  metrics:
+    tags:
+      application: ${spring.application.name}
+  prometheus:
+    metrics:
+      export:
+        enabled: true
+
+# ── Application-specific properties ────────────────────────────────────────────
+app:
+  jwt:
+    secret: ${JWT_SECRET:change-this-secret-in-production-must-be-at-least-256-bits-long-for-hs256-algorithm}
+    expiration-ms: ${JWT_EXPIRATION_MS:86400000}   # 24 hours
+
+  gateway:
+    success-rate: ${GATEWAY_SUCCESS_RATE:0.8}      # 80% success for realistic simulation
+    timeout-rate: ${GATEWAY_TIMEOUT_RATE:0.1}
+    fail-rate: ${GATEWAY_FAIL_RATE:0.1}
+    min-delay-ms: ${GATEWAY_MIN_DELAY_MS:100}
+    max-delay-ms: ${GATEWAY_MAX_DELAY_MS:500}
+
+  rate-limit:
+    max-requests-per-minute: ${RATE_LIMIT_MAX:10}
+    window-seconds: 60
+
+  kafka:
+    topics:
+      transaction-events: payment.transaction.events
+      transaction-dlq: payment.transaction.events.dlq
+
+# ── Resilience4j ────────────────────────────────────────────────────────────────
+resilience4j:
+  circuitbreaker:
+    instances:
+      payment-gateway:
+        failure-rate-threshold: 50            # open after 50% failures
+        slow-call-rate-threshold: 80          # treat calls > slow-call-duration as slow
+        slow-call-duration-threshold: 3s
+        sliding-window-type: COUNT_BASED
+        sliding-window-size: 10               # evaluate last 10 calls
+        minimum-number-of-calls: 5           # need at least 5 calls before opening
+        wait-duration-in-open-state: 30s      # stay OPEN for 30s
+        permitted-calls-in-half-open-state: 3 # allow 3 test calls in HALF_OPEN
+        automatic-transition-from-open-to-half-open-enabled: true
+        register-health-indicator: true
+  retry:
+    instances:
+      payment-gateway:
+        max-attempts: 3
+        wait-duration: 1s
+        exponential-backoff-multiplier: 2.0   # 1s → 2s → 4s
+        # retry-exceptions and ignore-exceptions reference gateway exception classes
+        # created in Task 12 — wired in at that point
+
+# ── Logging ─────────────────────────────────────────────────────────────────────
+logging:
+  level:
+    dev.cuong.payment: INFO
+    org.springframework.security: WARN
+    org.hibernate.SQL: WARN
+    org.apache.kafka: WARN

--- a/backend/bin/main/db/migration/V1__create_users_accounts.sql
+++ b/backend/bin/main/db/migration/V1__create_users_accounts.sql
@@ -1,0 +1,47 @@
+-- ─────────────────────────────────────────────────────────────────────────────
+-- V1: Users and Accounts
+--
+-- users    → identity and auth (JWT principal source)
+-- accounts → monetary balance; one per user, one-to-one enforced by UNIQUE
+--
+-- Money stored as NUMERIC(19,4) — never FLOAT (floating-point rounding corrupts
+-- financial calculations). TIMESTAMPTZ stores UTC; the app layer converts to
+-- local time, keeping the DB timezone-agnostic.
+-- ─────────────────────────────────────────────────────────────────────────────
+
+CREATE TABLE users (
+    id            UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+    username      VARCHAR(50)  NOT NULL,
+    email         VARCHAR(255) NOT NULL,
+    password_hash VARCHAR(255) NOT NULL,
+    role          VARCHAR(20)  NOT NULL DEFAULT 'USER',
+    created_at    TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    updated_at    TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+
+    CONSTRAINT uq_users_username UNIQUE (username),
+    CONSTRAINT uq_users_email    UNIQUE (email),
+    CONSTRAINT ck_users_role     CHECK  (role IN ('USER', 'ADMIN'))
+);
+
+-- ─────────────────────────────────────────────────────────────────────────────
+
+CREATE TABLE accounts (
+    id         UUID           PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id    UUID           NOT NULL,
+    balance    NUMERIC(19, 4) NOT NULL DEFAULT 0.0000,
+    currency   VARCHAR(3)     NOT NULL DEFAULT 'USD',
+    -- version supports optimistic locking (@Version in JPA) for read-heavy paths,
+    -- but balance deductions use SELECT FOR UPDATE (pessimistic) to prevent
+    -- overdraft under concurrent updates.
+    version    BIGINT         NOT NULL DEFAULT 0,
+    created_at TIMESTAMPTZ    NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ    NOT NULL DEFAULT NOW(),
+
+    CONSTRAINT fk_accounts_user    FOREIGN KEY (user_id) REFERENCES users (id),
+    CONSTRAINT uq_accounts_user_id UNIQUE (user_id),
+    CONSTRAINT ck_accounts_balance CHECK  (balance >= 0)
+);
+
+-- Covered by UNIQUE constraint above, but explicit index improves readability
+-- in EXPLAIN plans and is used by the pessimistic-lock query path.
+CREATE INDEX idx_accounts_user_id ON accounts (user_id);

--- a/backend/bin/main/db/migration/V2__create_transactions.sql
+++ b/backend/bin/main/db/migration/V2__create_transactions.sql
@@ -1,0 +1,54 @@
+-- ─────────────────────────────────────────────────────────────────────────────
+-- V2: Transactions
+--
+-- Central entity. The status column enforces the state machine at the DB level
+-- as a secondary safety net — the application enforces the same transitions.
+-- Having the constraint in both layers means a bug in one cannot corrupt the
+-- other; any invalid state is caught at whichever boundary it reaches first.
+--
+-- State machine: PENDING → PROCESSING → SUCCESS | FAILED | TIMEOUT → REFUNDED
+--
+-- version supports JPA @Version (optimistic locking) for concurrent read-modify-
+-- write without full row locking — appropriate here because most concurrent
+-- updates are to different transactions, so lock contention is low.
+-- ─────────────────────────────────────────────────────────────────────────────
+
+CREATE TABLE transactions (
+    id                UUID           PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id           UUID           NOT NULL,
+    account_id        UUID           NOT NULL,
+    amount            NUMERIC(19, 4) NOT NULL,
+    currency          VARCHAR(3)     NOT NULL DEFAULT 'USD',
+    type              VARCHAR(20)    NOT NULL,
+    status            VARCHAR(20)    NOT NULL DEFAULT 'PENDING',
+    description       VARCHAR(500),
+    idempotency_key   VARCHAR(255),
+    gateway_reference VARCHAR(255),
+    failure_reason    TEXT,
+    version           BIGINT         NOT NULL DEFAULT 0,
+    processed_at      TIMESTAMPTZ,
+    refunded_at       TIMESTAMPTZ,
+    created_at        TIMESTAMPTZ    NOT NULL DEFAULT NOW(),
+    updated_at        TIMESTAMPTZ    NOT NULL DEFAULT NOW(),
+
+    CONSTRAINT fk_transactions_user    FOREIGN KEY (user_id)    REFERENCES users    (id),
+    CONSTRAINT fk_transactions_account FOREIGN KEY (account_id) REFERENCES accounts (id),
+    CONSTRAINT ck_transactions_amount  CHECK (amount > 0),
+    CONSTRAINT ck_transactions_type    CHECK (type   IN ('PAYMENT', 'DEPOSIT', 'TRANSFER')),
+    CONSTRAINT ck_transactions_status  CHECK (status IN ('PENDING', 'PROCESSING', 'SUCCESS',
+                                                         'FAILED', 'TIMEOUT', 'REFUNDED'))
+);
+
+-- Most frequent query: "show me my transactions, newest first".
+-- Composite index on (user_id, created_at DESC) covers this in one index scan.
+CREATE INDEX idx_transactions_user_created   ON transactions (user_id, created_at DESC);
+
+-- Partial index: only PENDING and PROCESSING rows need fast status lookups
+-- (monitoring, stuck-transaction detection). Terminal states are cold data.
+CREATE INDEX idx_transactions_active_status  ON transactions (status)
+    WHERE status IN ('PENDING', 'PROCESSING');
+
+-- Idempotency check on the write path — must be fast. Partial index keeps it
+-- small by excluding rows where idempotency_key is not set (e.g. DEPOSIT).
+CREATE INDEX idx_transactions_idempotency    ON transactions (idempotency_key)
+    WHERE idempotency_key IS NOT NULL;

--- a/backend/bin/main/db/migration/V3__create_idempotency_keys.sql
+++ b/backend/bin/main/db/migration/V3__create_idempotency_keys.sql
@@ -1,0 +1,35 @@
+-- ─────────────────────────────────────────────────────────────────────────────
+-- V3: Idempotency Keys
+--
+-- Stores the cached response for each Idempotency-Key header so that retried
+-- requests receive the original response without re-executing the operation.
+--
+-- request_hash (SHA-256 of request body) guards against the misuse case where
+-- a client reuses the same key with a different request — we detect this and
+-- return 422 rather than silently returning the wrong cached response.
+--
+-- expires_at is set by the application (typically NOW() + 24h). A scheduled
+-- job (Task 14) will periodically DELETE expired rows to keep the table small.
+-- ─────────────────────────────────────────────────────────────────────────────
+
+CREATE TABLE idempotency_keys (
+    id              UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+    idempotency_key VARCHAR(255) NOT NULL,
+    user_id         UUID         NOT NULL,
+    request_hash    VARCHAR(64)  NOT NULL,
+    response_status INT          NOT NULL,
+    response_body   TEXT         NOT NULL,
+    created_at      TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    expires_at      TIMESTAMPTZ  NOT NULL,
+
+    CONSTRAINT uq_idempotency_key         UNIQUE (idempotency_key),
+    CONSTRAINT ck_idempotency_status_code CHECK  (response_status BETWEEN 100 AND 599)
+);
+
+-- Primary lookup on the write path: "has this key been used before?"
+CREATE INDEX idx_idempotency_keys_key     ON idempotency_keys (idempotency_key);
+
+-- Cleanup job: DELETE FROM idempotency_keys WHERE expires_at < NOW().
+-- Plain index (no partial predicate) because PostgreSQL requires index predicates
+-- to use only IMMUTABLE functions; NOW() is STABLE and is rejected at DDL time.
+CREATE INDEX idx_idempotency_keys_expires ON idempotency_keys (expires_at);

--- a/backend/bin/main/db/migration/V4__create_audit_dlq.sql
+++ b/backend/bin/main/db/migration/V4__create_audit_dlq.sql
@@ -1,0 +1,63 @@
+-- ─────────────────────────────────────────────────────────────────────────────
+-- V4: Audit Logs and Dead Letter Events
+--
+-- audit_logs         → immutable append-only record of every significant event.
+--                      Required for financial compliance (who did what, when).
+--                      Never UPDATE or DELETE rows — write new corrections instead.
+--
+-- dead_letter_events → Kafka messages that failed processing after max retries.
+--                      Stored here so admins can inspect, retry, or discard them.
+--                      resolved_at/resolved_by track the remediation audit trail.
+-- ─────────────────────────────────────────────────────────────────────────────
+
+CREATE TABLE audit_logs (
+    id             UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+    -- transaction_id is nullable: some events are user-level (login, account created)
+    -- rather than transaction-scoped.
+    transaction_id UUID,
+    user_id        UUID         NOT NULL,
+    event_type     VARCHAR(50)  NOT NULL,
+    old_status     VARCHAR(20),
+    new_status     VARCHAR(20),
+    -- JSONB allows querying nested fields (e.g. metadata->>'ip') and GIN indexing
+    -- if compliance queries require it in future.
+    metadata       JSONB,
+    created_at     TIMESTAMPTZ  NOT NULL DEFAULT NOW()
+);
+
+-- All audit events for a specific transaction (core compliance query).
+CREATE INDEX idx_audit_logs_transaction_id ON audit_logs (transaction_id)
+    WHERE transaction_id IS NOT NULL;
+
+-- Time-range compliance queries: "all events in this 30-day window".
+CREATE INDEX idx_audit_logs_created_at     ON audit_logs (created_at DESC);
+
+-- User-scoped audit trail.
+CREATE INDEX idx_audit_logs_user_created   ON audit_logs (user_id, created_at DESC);
+
+-- ─────────────────────────────────────────────────────────────────────────────
+
+CREATE TABLE dead_letter_events (
+    id               UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+    topic            VARCHAR(255) NOT NULL,
+    -- Kafka partition + offset identify the exact message for re-processing.
+    -- Nullable because some error paths (e.g. deserialization) occur before
+    -- offset is assigned.
+    kafka_partition  INT,
+    kafka_offset     BIGINT,
+    payload          TEXT         NOT NULL,
+    error_message    TEXT         NOT NULL,
+    retry_count      INT          NOT NULL DEFAULT 0,
+    created_at       TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    resolved_at      TIMESTAMPTZ,
+    resolved_by      VARCHAR(255)
+);
+
+-- Admin DLQ viewer primary view: unresolved events, newest first.
+-- Partial index excludes already-resolved rows — keeps the index small.
+CREATE INDEX idx_dlq_unresolved ON dead_letter_events (created_at DESC)
+    WHERE resolved_at IS NULL;
+
+-- Historical audit: all resolved events ordered by resolution time.
+CREATE INDEX idx_dlq_resolved   ON dead_letter_events (resolved_at DESC)
+    WHERE resolved_at IS NOT NULL;

--- a/backend/bin/main/redisson-local.yaml
+++ b/backend/bin/main/redisson-local.yaml
@@ -1,0 +1,22 @@
+# Redisson explicit config for local development.
+# Used instead of spring.data.redis.* auto-configuration to ensure reliable
+# Netty-based connection on Windows/WSL2 where auto-config sometimes fails.
+#
+# This file is activated via: spring.redis.config=classpath:redisson-local.yaml
+# in application-local.yml.
+
+singleServerConfig:
+  # With preferIPv6Addresses=true (set in build.gradle bootRun jvmArgs),
+  # "localhost" resolves to ::1 which IS the Docker Desktop listener on this machine.
+  address: "redis://localhost:6379"
+  connectionPoolSize: 8
+  connectionMinimumIdleSize: 2
+  idleConnectionTimeout: 10000
+  connectTimeout: 5000
+  timeout: 3000
+  retryAttempts: 3
+  retryInterval: 1500
+
+threads: 4
+nettyThreads: 4
+codec: !<org.redisson.codec.JsonJacksonCodec> {}

--- a/backend/src/main/resources/db/migration/V1__create_users_accounts.sql
+++ b/backend/src/main/resources/db/migration/V1__create_users_accounts.sql
@@ -1,0 +1,47 @@
+-- ─────────────────────────────────────────────────────────────────────────────
+-- V1: Users and Accounts
+--
+-- users    → identity and auth (JWT principal source)
+-- accounts → monetary balance; one per user, one-to-one enforced by UNIQUE
+--
+-- Money stored as NUMERIC(19,4) — never FLOAT (floating-point rounding corrupts
+-- financial calculations). TIMESTAMPTZ stores UTC; the app layer converts to
+-- local time, keeping the DB timezone-agnostic.
+-- ─────────────────────────────────────────────────────────────────────────────
+
+CREATE TABLE users (
+    id            UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+    username      VARCHAR(50)  NOT NULL,
+    email         VARCHAR(255) NOT NULL,
+    password_hash VARCHAR(255) NOT NULL,
+    role          VARCHAR(20)  NOT NULL DEFAULT 'USER',
+    created_at    TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    updated_at    TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+
+    CONSTRAINT uq_users_username UNIQUE (username),
+    CONSTRAINT uq_users_email    UNIQUE (email),
+    CONSTRAINT ck_users_role     CHECK  (role IN ('USER', 'ADMIN'))
+);
+
+-- ─────────────────────────────────────────────────────────────────────────────
+
+CREATE TABLE accounts (
+    id         UUID           PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id    UUID           NOT NULL,
+    balance    NUMERIC(19, 4) NOT NULL DEFAULT 0.0000,
+    currency   VARCHAR(3)     NOT NULL DEFAULT 'USD',
+    -- version supports optimistic locking (@Version in JPA) for read-heavy paths,
+    -- but balance deductions use SELECT FOR UPDATE (pessimistic) to prevent
+    -- overdraft under concurrent updates.
+    version    BIGINT         NOT NULL DEFAULT 0,
+    created_at TIMESTAMPTZ    NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ    NOT NULL DEFAULT NOW(),
+
+    CONSTRAINT fk_accounts_user    FOREIGN KEY (user_id) REFERENCES users (id),
+    CONSTRAINT uq_accounts_user_id UNIQUE (user_id),
+    CONSTRAINT ck_accounts_balance CHECK  (balance >= 0)
+);
+
+-- Covered by UNIQUE constraint above, but explicit index improves readability
+-- in EXPLAIN plans and is used by the pessimistic-lock query path.
+CREATE INDEX idx_accounts_user_id ON accounts (user_id);

--- a/backend/src/main/resources/db/migration/V2__create_transactions.sql
+++ b/backend/src/main/resources/db/migration/V2__create_transactions.sql
@@ -1,0 +1,54 @@
+-- ─────────────────────────────────────────────────────────────────────────────
+-- V2: Transactions
+--
+-- Central entity. The status column enforces the state machine at the DB level
+-- as a secondary safety net — the application enforces the same transitions.
+-- Having the constraint in both layers means a bug in one cannot corrupt the
+-- other; any invalid state is caught at whichever boundary it reaches first.
+--
+-- State machine: PENDING → PROCESSING → SUCCESS | FAILED | TIMEOUT → REFUNDED
+--
+-- version supports JPA @Version (optimistic locking) for concurrent read-modify-
+-- write without full row locking — appropriate here because most concurrent
+-- updates are to different transactions, so lock contention is low.
+-- ─────────────────────────────────────────────────────────────────────────────
+
+CREATE TABLE transactions (
+    id                UUID           PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id           UUID           NOT NULL,
+    account_id        UUID           NOT NULL,
+    amount            NUMERIC(19, 4) NOT NULL,
+    currency          VARCHAR(3)     NOT NULL DEFAULT 'USD',
+    type              VARCHAR(20)    NOT NULL,
+    status            VARCHAR(20)    NOT NULL DEFAULT 'PENDING',
+    description       VARCHAR(500),
+    idempotency_key   VARCHAR(255),
+    gateway_reference VARCHAR(255),
+    failure_reason    TEXT,
+    version           BIGINT         NOT NULL DEFAULT 0,
+    processed_at      TIMESTAMPTZ,
+    refunded_at       TIMESTAMPTZ,
+    created_at        TIMESTAMPTZ    NOT NULL DEFAULT NOW(),
+    updated_at        TIMESTAMPTZ    NOT NULL DEFAULT NOW(),
+
+    CONSTRAINT fk_transactions_user    FOREIGN KEY (user_id)    REFERENCES users    (id),
+    CONSTRAINT fk_transactions_account FOREIGN KEY (account_id) REFERENCES accounts (id),
+    CONSTRAINT ck_transactions_amount  CHECK (amount > 0),
+    CONSTRAINT ck_transactions_type    CHECK (type   IN ('PAYMENT', 'DEPOSIT', 'TRANSFER')),
+    CONSTRAINT ck_transactions_status  CHECK (status IN ('PENDING', 'PROCESSING', 'SUCCESS',
+                                                         'FAILED', 'TIMEOUT', 'REFUNDED'))
+);
+
+-- Most frequent query: "show me my transactions, newest first".
+-- Composite index on (user_id, created_at DESC) covers this in one index scan.
+CREATE INDEX idx_transactions_user_created   ON transactions (user_id, created_at DESC);
+
+-- Partial index: only PENDING and PROCESSING rows need fast status lookups
+-- (monitoring, stuck-transaction detection). Terminal states are cold data.
+CREATE INDEX idx_transactions_active_status  ON transactions (status)
+    WHERE status IN ('PENDING', 'PROCESSING');
+
+-- Idempotency check on the write path — must be fast. Partial index keeps it
+-- small by excluding rows where idempotency_key is not set (e.g. DEPOSIT).
+CREATE INDEX idx_transactions_idempotency    ON transactions (idempotency_key)
+    WHERE idempotency_key IS NOT NULL;

--- a/backend/src/main/resources/db/migration/V3__create_idempotency_keys.sql
+++ b/backend/src/main/resources/db/migration/V3__create_idempotency_keys.sql
@@ -1,0 +1,35 @@
+-- ─────────────────────────────────────────────────────────────────────────────
+-- V3: Idempotency Keys
+--
+-- Stores the cached response for each Idempotency-Key header so that retried
+-- requests receive the original response without re-executing the operation.
+--
+-- request_hash (SHA-256 of request body) guards against the misuse case where
+-- a client reuses the same key with a different request — we detect this and
+-- return 422 rather than silently returning the wrong cached response.
+--
+-- expires_at is set by the application (typically NOW() + 24h). A scheduled
+-- job (Task 14) will periodically DELETE expired rows to keep the table small.
+-- ─────────────────────────────────────────────────────────────────────────────
+
+CREATE TABLE idempotency_keys (
+    id              UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+    idempotency_key VARCHAR(255) NOT NULL,
+    user_id         UUID         NOT NULL,
+    request_hash    VARCHAR(64)  NOT NULL,
+    response_status INT          NOT NULL,
+    response_body   TEXT         NOT NULL,
+    created_at      TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    expires_at      TIMESTAMPTZ  NOT NULL,
+
+    CONSTRAINT uq_idempotency_key         UNIQUE (idempotency_key),
+    CONSTRAINT ck_idempotency_status_code CHECK  (response_status BETWEEN 100 AND 599)
+);
+
+-- Primary lookup on the write path: "has this key been used before?"
+CREATE INDEX idx_idempotency_keys_key     ON idempotency_keys (idempotency_key);
+
+-- Cleanup job: DELETE FROM idempotency_keys WHERE expires_at < NOW().
+-- Plain index (no partial predicate) because PostgreSQL requires index predicates
+-- to use only IMMUTABLE functions; NOW() is STABLE and is rejected at DDL time.
+CREATE INDEX idx_idempotency_keys_expires ON idempotency_keys (expires_at);

--- a/backend/src/main/resources/db/migration/V4__create_audit_dlq.sql
+++ b/backend/src/main/resources/db/migration/V4__create_audit_dlq.sql
@@ -1,0 +1,63 @@
+-- ─────────────────────────────────────────────────────────────────────────────
+-- V4: Audit Logs and Dead Letter Events
+--
+-- audit_logs         → immutable append-only record of every significant event.
+--                      Required for financial compliance (who did what, when).
+--                      Never UPDATE or DELETE rows — write new corrections instead.
+--
+-- dead_letter_events → Kafka messages that failed processing after max retries.
+--                      Stored here so admins can inspect, retry, or discard them.
+--                      resolved_at/resolved_by track the remediation audit trail.
+-- ─────────────────────────────────────────────────────────────────────────────
+
+CREATE TABLE audit_logs (
+    id             UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+    -- transaction_id is nullable: some events are user-level (login, account created)
+    -- rather than transaction-scoped.
+    transaction_id UUID,
+    user_id        UUID         NOT NULL,
+    event_type     VARCHAR(50)  NOT NULL,
+    old_status     VARCHAR(20),
+    new_status     VARCHAR(20),
+    -- JSONB allows querying nested fields (e.g. metadata->>'ip') and GIN indexing
+    -- if compliance queries require it in future.
+    metadata       JSONB,
+    created_at     TIMESTAMPTZ  NOT NULL DEFAULT NOW()
+);
+
+-- All audit events for a specific transaction (core compliance query).
+CREATE INDEX idx_audit_logs_transaction_id ON audit_logs (transaction_id)
+    WHERE transaction_id IS NOT NULL;
+
+-- Time-range compliance queries: "all events in this 30-day window".
+CREATE INDEX idx_audit_logs_created_at     ON audit_logs (created_at DESC);
+
+-- User-scoped audit trail.
+CREATE INDEX idx_audit_logs_user_created   ON audit_logs (user_id, created_at DESC);
+
+-- ─────────────────────────────────────────────────────────────────────────────
+
+CREATE TABLE dead_letter_events (
+    id               UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+    topic            VARCHAR(255) NOT NULL,
+    -- Kafka partition + offset identify the exact message for re-processing.
+    -- Nullable because some error paths (e.g. deserialization) occur before
+    -- offset is assigned.
+    kafka_partition  INT,
+    kafka_offset     BIGINT,
+    payload          TEXT         NOT NULL,
+    error_message    TEXT         NOT NULL,
+    retry_count      INT          NOT NULL DEFAULT 0,
+    created_at       TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    resolved_at      TIMESTAMPTZ,
+    resolved_by      VARCHAR(255)
+);
+
+-- Admin DLQ viewer primary view: unresolved events, newest first.
+-- Partial index excludes already-resolved rows — keeps the index small.
+CREATE INDEX idx_dlq_unresolved ON dead_letter_events (created_at DESC)
+    WHERE resolved_at IS NULL;
+
+-- Historical audit: all resolved events ordered by resolution time.
+CREATE INDEX idx_dlq_resolved   ON dead_letter_events (resolved_at DESC)
+    WHERE resolved_at IS NOT NULL;

--- a/backend/src/test/java/dev/cuong/payment/migration/FlywayMigrationIntegrationTest.java
+++ b/backend/src/test/java/dev/cuong/payment/migration/FlywayMigrationIntegrationTest.java
@@ -1,0 +1,190 @@
+package dev.cuong.payment.migration;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.transaction.annotation.Transactional;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Verifies that all Flyway migrations apply cleanly and that critical database
+ * constraints (money non-negative, valid status values) are enforced at the
+ * storage layer — independent of application logic.
+ *
+ * <p>Uses a real PostgreSQL container so the SQL is executed against the same
+ * engine as production. H2 compatibility mode cannot catch all PG-specific
+ * constraint or syntax errors.
+ */
+@SpringBootTest
+@Testcontainers
+@TestPropertySource(properties = {
+    // Redis and Kafka are not needed for schema verification.
+    "spring.autoconfigure.exclude=" +
+        "org.redisson.spring.starter.RedissonAutoConfigurationV2," +
+        "org.springframework.boot.autoconfigure.kafka.KafkaAutoConfiguration",
+    "spring.flyway.enabled=true",
+    "spring.flyway.validate-on-migrate=true",
+    "spring.jpa.hibernate.ddl-auto=validate"
+})
+class FlywayMigrationIntegrationTest {
+
+    // Static container shared across all tests in this class — one PostgreSQL
+    // instance is started per test class, not per test method.
+    @Container
+    @ServiceConnection
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:15-alpine");
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Test
+    void should_apply_all_migrations_and_create_expected_tables() {
+        List<String> tables = jdbcTemplate.queryForList(
+            "SELECT tablename FROM pg_tables WHERE schemaname = 'public' ORDER BY tablename",
+            String.class
+        );
+
+        assertThat(tables).containsExactlyInAnyOrder(
+            "users",
+            "accounts",
+            "transactions",
+            "idempotency_keys",
+            "audit_logs",
+            "dead_letter_events",
+            "flyway_schema_history"
+        );
+    }
+
+    @Test
+    void should_record_all_four_migrations_in_flyway_history() {
+        List<String> appliedVersions = jdbcTemplate.queryForList(
+            "SELECT version FROM flyway_schema_history WHERE success = true ORDER BY installed_rank",
+            String.class
+        );
+
+        assertThat(appliedVersions).containsExactly("1", "2", "3", "4");
+    }
+
+    @Test
+    @Transactional
+    void should_reject_negative_account_balance() {
+        jdbcTemplate.execute("""
+            INSERT INTO users (id, username, email, password_hash, role)
+            VALUES ('10000000-0000-0000-0000-000000000001',
+                    'balanceuser', 'balance@test.com', 'hash', 'USER')
+            """);
+
+        assertThatThrownBy(() -> jdbcTemplate.execute("""
+            INSERT INTO accounts (user_id, balance)
+            VALUES ('10000000-0000-0000-0000-000000000001', -0.0001)
+            """))
+            .isInstanceOf(DataIntegrityViolationException.class)
+            .hasMessageContaining("ck_accounts_balance");
+    }
+
+    @Test
+    @Transactional
+    void should_reject_invalid_transaction_status() {
+        jdbcTemplate.execute("""
+            INSERT INTO users (id, username, email, password_hash, role)
+            VALUES ('20000000-0000-0000-0000-000000000001',
+                    'statususer', 'status@test.com', 'hash', 'USER')
+            """);
+        jdbcTemplate.execute("""
+            INSERT INTO accounts (id, user_id, balance)
+            VALUES ('20000000-0000-0000-0000-000000000001',
+                    '20000000-0000-0000-0000-000000000001', 1000.00)
+            """);
+
+        assertThatThrownBy(() -> jdbcTemplate.execute("""
+            INSERT INTO transactions (user_id, account_id, amount, type, status)
+            VALUES ('20000000-0000-0000-0000-000000000001',
+                    '20000000-0000-0000-0000-000000000001',
+                    100.00, 'PAYMENT', 'BOGUS_STATUS')
+            """))
+            .isInstanceOf(DataIntegrityViolationException.class)
+            .hasMessageContaining("ck_transactions_status");
+    }
+
+    @Test
+    @Transactional
+    void should_reject_invalid_transaction_type() {
+        jdbcTemplate.execute("""
+            INSERT INTO users (id, username, email, password_hash, role)
+            VALUES ('30000000-0000-0000-0000-000000000001',
+                    'typeuser', 'type@test.com', 'hash', 'USER')
+            """);
+        jdbcTemplate.execute("""
+            INSERT INTO accounts (id, user_id, balance)
+            VALUES ('30000000-0000-0000-0000-000000000001',
+                    '30000000-0000-0000-0000-000000000001', 500.00)
+            """);
+
+        assertThatThrownBy(() -> jdbcTemplate.execute("""
+            INSERT INTO transactions (user_id, account_id, amount, type)
+            VALUES ('30000000-0000-0000-0000-000000000001',
+                    '30000000-0000-0000-0000-000000000001',
+                    50.00, 'WIRE_TRANSFER')
+            """))
+            .isInstanceOf(DataIntegrityViolationException.class)
+            .hasMessageContaining("ck_transactions_type");
+    }
+
+    @Test
+    @Transactional
+    void should_reject_zero_or_negative_transaction_amount() {
+        jdbcTemplate.execute("""
+            INSERT INTO users (id, username, email, password_hash, role)
+            VALUES ('40000000-0000-0000-0000-000000000001',
+                    'amountuser', 'amount@test.com', 'hash', 'USER')
+            """);
+        jdbcTemplate.execute("""
+            INSERT INTO accounts (id, user_id, balance)
+            VALUES ('40000000-0000-0000-0000-000000000001',
+                    '40000000-0000-0000-0000-000000000001', 200.00)
+            """);
+
+        assertThatThrownBy(() -> jdbcTemplate.execute("""
+            INSERT INTO transactions (user_id, account_id, amount, type)
+            VALUES ('40000000-0000-0000-0000-000000000001',
+                    '40000000-0000-0000-0000-000000000001',
+                    0.00, 'PAYMENT')
+            """))
+            .isInstanceOf(DataIntegrityViolationException.class)
+            .hasMessageContaining("ck_transactions_amount");
+    }
+
+    @Test
+    @Transactional
+    void should_enforce_one_account_per_user() {
+        jdbcTemplate.execute("""
+            INSERT INTO users (id, username, email, password_hash, role)
+            VALUES ('50000000-0000-0000-0000-000000000001',
+                    'oneaccuser', 'oneacc@test.com', 'hash', 'USER')
+            """);
+        jdbcTemplate.execute("""
+            INSERT INTO accounts (id, user_id, balance)
+            VALUES ('50000000-0000-0000-0000-000000000001',
+                    '50000000-0000-0000-0000-000000000001', 100.00)
+            """);
+
+        assertThatThrownBy(() -> jdbcTemplate.execute("""
+            INSERT INTO accounts (id, user_id, balance)
+            VALUES ('50000000-0000-0000-0000-000000000002',
+                    '50000000-0000-0000-0000-000000000001', 200.00)
+            """))
+            .isInstanceOf(DataIntegrityViolationException.class)
+            .hasMessageContaining("uq_accounts_user_id");
+    }
+}


### PR DESCRIPTION
## What this PR does
Closes #2

Establishes the entire database schema as versioned Flyway migrations.
All 6 application tables are created with explicit constraints, foreign keys,
and targeted indexes. Schema is now reproducible from zero on any environment.

## How to test
./gradlew test --tests "dev.cuong.payment.migration.FlywayMigrationIntegrationTest"
# All 7 tests should pass (real PostgreSQL via Testcontainers)

# Optionally verify against Docker Postgres:
docker-compose up -d postgres
./gradlew bootRun --args='--spring.profiles.active=local'
# Should see "Successfully validated 4 migrations" and "Schema up to date" in logs.

## Technical decisions
- NUMERIC(19,4) for all money columns — never FLOAT (floating-point imprecision corrupts ledgers)
- TIMESTAMPTZ everywhere — stores UTC, presentation layer converts to local time
- CHECK constraints in SQL duplicate the Java state machine — belt-and-suspenders; a bug in one layer can't corrupt the other
- Partial indexes on active transaction status only — terminal states are cold data and excluded to keep the index small