### PR TITLE
Task/03-domain-model

### DIFF
--- a/backend/src/main/java/dev/cuong/payment/domain/exception/AccountNotFoundException.java
+++ b/backend/src/main/java/dev/cuong/payment/domain/exception/AccountNotFoundException.java
@@ -1,0 +1,10 @@
+package dev.cuong.payment.domain.exception;
+
+import java.util.UUID;
+
+public class AccountNotFoundException extends DomainException {
+
+    public AccountNotFoundException(UUID userId) {
+        super("Account not found for user: " + userId);
+    }
+}

--- a/backend/src/main/java/dev/cuong/payment/domain/exception/DomainException.java
+++ b/backend/src/main/java/dev/cuong/payment/domain/exception/DomainException.java
@@ -1,0 +1,12 @@
+package dev.cuong.payment.domain.exception;
+
+public abstract class DomainException extends RuntimeException {
+
+    protected DomainException(String message) {
+        super(message);
+    }
+
+    protected DomainException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/backend/src/main/java/dev/cuong/payment/domain/exception/InsufficientFundsException.java
+++ b/backend/src/main/java/dev/cuong/payment/domain/exception/InsufficientFundsException.java
@@ -1,0 +1,32 @@
+package dev.cuong.payment.domain.exception;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+public class InsufficientFundsException extends DomainException {
+
+    private final UUID userId;
+    private final BigDecimal balance;
+    private final BigDecimal requested;
+
+    public InsufficientFundsException(UUID userId, BigDecimal balance, BigDecimal requested) {
+        super(String.format(
+                "Insufficient funds for user %s: balance=%s, requested=%s",
+                userId, balance, requested));
+        this.userId = userId;
+        this.balance = balance;
+        this.requested = requested;
+    }
+
+    public UUID getUserId() {
+        return userId;
+    }
+
+    public BigDecimal getBalance() {
+        return balance;
+    }
+
+    public BigDecimal getRequested() {
+        return requested;
+    }
+}

--- a/backend/src/main/java/dev/cuong/payment/domain/exception/InvalidTransactionStateException.java
+++ b/backend/src/main/java/dev/cuong/payment/domain/exception/InvalidTransactionStateException.java
@@ -1,0 +1,23 @@
+package dev.cuong.payment.domain.exception;
+
+import dev.cuong.payment.domain.vo.TransactionStatus;
+
+public class InvalidTransactionStateException extends DomainException {
+
+    private final TransactionStatus from;
+    private final TransactionStatus to;
+
+    public InvalidTransactionStateException(TransactionStatus from, TransactionStatus to) {
+        super(String.format("Cannot transition transaction from %s to %s", from, to));
+        this.from = from;
+        this.to = to;
+    }
+
+    public TransactionStatus getFrom() {
+        return from;
+    }
+
+    public TransactionStatus getTo() {
+        return to;
+    }
+}

--- a/backend/src/main/java/dev/cuong/payment/domain/exception/TransactionNotFoundException.java
+++ b/backend/src/main/java/dev/cuong/payment/domain/exception/TransactionNotFoundException.java
@@ -1,0 +1,10 @@
+package dev.cuong.payment.domain.exception;
+
+import java.util.UUID;
+
+public class TransactionNotFoundException extends DomainException {
+
+    public TransactionNotFoundException(UUID transactionId) {
+        super("Transaction not found: " + transactionId);
+    }
+}

--- a/backend/src/main/java/dev/cuong/payment/domain/exception/UserNotFoundException.java
+++ b/backend/src/main/java/dev/cuong/payment/domain/exception/UserNotFoundException.java
@@ -1,0 +1,10 @@
+package dev.cuong.payment.domain.exception;
+
+import java.util.UUID;
+
+public class UserNotFoundException extends DomainException {
+
+    public UserNotFoundException(UUID userId) {
+        super("User not found: " + userId);
+    }
+}

--- a/backend/src/main/java/dev/cuong/payment/domain/model/Account.java
+++ b/backend/src/main/java/dev/cuong/payment/domain/model/Account.java
@@ -1,0 +1,40 @@
+package dev.cuong.payment.domain.model;
+
+import dev.cuong.payment.domain.exception.InsufficientFundsException;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+
+@Getter
+@Builder
+public class Account {
+
+    private final UUID id;
+    private final UUID userId;
+    private BigDecimal balance;
+    private final String currency;
+    private long version;
+    private final Instant createdAt;
+    private Instant updatedAt;
+
+    /**
+     * Reduces the balance by {@code amount}.
+     * Throws {@link InsufficientFundsException} if the account has insufficient funds,
+     * enforcing the non-negative balance invariant at the domain layer.
+     */
+    public void debit(BigDecimal amount) {
+        if (balance.compareTo(amount) < 0) {
+            throw new InsufficientFundsException(userId, balance, amount);
+        }
+        this.balance = balance.subtract(amount);
+        this.updatedAt = Instant.now();
+    }
+
+    public void credit(BigDecimal amount) {
+        this.balance = balance.add(amount);
+        this.updatedAt = Instant.now();
+    }
+}

--- a/backend/src/main/java/dev/cuong/payment/domain/model/Transaction.java
+++ b/backend/src/main/java/dev/cuong/payment/domain/model/Transaction.java
@@ -1,0 +1,68 @@
+package dev.cuong.payment.domain.model;
+
+import dev.cuong.payment.domain.vo.TransactionStatus;
+import dev.cuong.payment.domain.vo.TransactionType;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * Aggregate root for a payment transaction.
+ *
+ * <p>All status changes are routed through the business methods below, which
+ * delegate to {@link TransactionStatus#transitionTo} to enforce the state machine.
+ * It is impossible to set {@code status} directly — there is no setter.
+ */
+@Getter
+@Builder
+public class Transaction {
+
+    private final UUID id;
+    private final UUID userId;
+    private final UUID accountId;
+    private final BigDecimal amount;
+    private final String currency;
+    private final TransactionType type;
+    private TransactionStatus status;
+    private final String description;
+    private final String idempotencyKey;
+    private String gatewayReference;
+    private String failureReason;
+    private long version;
+    private Instant processedAt;
+    private Instant refundedAt;
+    private final Instant createdAt;
+    private Instant updatedAt;
+
+    public void startProcessing() {
+        this.status = status.transitionTo(TransactionStatus.PROCESSING);
+        this.updatedAt = Instant.now();
+    }
+
+    public void complete(String gatewayRef) {
+        this.status = status.transitionTo(TransactionStatus.SUCCESS);
+        this.gatewayReference = gatewayRef;
+        this.processedAt = Instant.now();
+        this.updatedAt = Instant.now();
+    }
+
+    public void fail(String reason) {
+        this.status = status.transitionTo(TransactionStatus.FAILED);
+        this.failureReason = reason;
+        this.updatedAt = Instant.now();
+    }
+
+    public void timeout() {
+        this.status = status.transitionTo(TransactionStatus.TIMEOUT);
+        this.updatedAt = Instant.now();
+    }
+
+    public void refund() {
+        this.status = status.transitionTo(TransactionStatus.REFUNDED);
+        this.refundedAt = Instant.now();
+        this.updatedAt = Instant.now();
+    }
+}

--- a/backend/src/main/java/dev/cuong/payment/domain/model/User.java
+++ b/backend/src/main/java/dev/cuong/payment/domain/model/User.java
@@ -1,0 +1,25 @@
+package dev.cuong.payment.domain.model;
+
+import dev.cuong.payment.domain.vo.UserRole;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Getter
+@Builder
+public class User {
+
+    private final UUID id;
+    private final String username;
+    private final String email;
+    private final String passwordHash;
+    private final UserRole role;
+    private final Instant createdAt;
+    private final Instant updatedAt;
+
+    public boolean isAdmin() {
+        return role == UserRole.ADMIN;
+    }
+}

--- a/backend/src/main/java/dev/cuong/payment/domain/vo/TransactionStatus.java
+++ b/backend/src/main/java/dev/cuong/payment/domain/vo/TransactionStatus.java
@@ -1,0 +1,50 @@
+package dev.cuong.payment.domain.vo;
+
+import dev.cuong.payment.domain.exception.InvalidTransactionStateException;
+
+import java.util.EnumMap;
+import java.util.EnumSet;
+import java.util.Map;
+import java.util.Set;
+
+public enum TransactionStatus {
+
+    PENDING,
+    PROCESSING,
+    SUCCESS,
+    FAILED,
+    TIMEOUT,
+    REFUNDED;
+
+    private static final Map<TransactionStatus, Set<TransactionStatus>> ALLOWED_TRANSITIONS;
+
+    static {
+        ALLOWED_TRANSITIONS = new EnumMap<>(TransactionStatus.class);
+        ALLOWED_TRANSITIONS.put(PENDING,    EnumSet.of(PROCESSING));
+        ALLOWED_TRANSITIONS.put(PROCESSING, EnumSet.of(SUCCESS, FAILED, TIMEOUT));
+        ALLOWED_TRANSITIONS.put(SUCCESS,    EnumSet.of(REFUNDED));
+        ALLOWED_TRANSITIONS.put(FAILED,     EnumSet.noneOf(TransactionStatus.class));
+        ALLOWED_TRANSITIONS.put(TIMEOUT,    EnumSet.noneOf(TransactionStatus.class));
+        ALLOWED_TRANSITIONS.put(REFUNDED,   EnumSet.noneOf(TransactionStatus.class));
+    }
+
+    /**
+     * Validates and returns the target status.
+     * Throws {@link InvalidTransactionStateException} if the transition is not allowed
+     * by the state machine, making illegal state changes impossible to bypass.
+     */
+    public TransactionStatus transitionTo(TransactionStatus target) {
+        if (!ALLOWED_TRANSITIONS.get(this).contains(target)) {
+            throw new InvalidTransactionStateException(this, target);
+        }
+        return target;
+    }
+
+    public boolean isTerminal() {
+        return this == FAILED || this == TIMEOUT || this == REFUNDED;
+    }
+
+    public boolean canBeRefunded() {
+        return this == SUCCESS;
+    }
+}

--- a/backend/src/main/java/dev/cuong/payment/domain/vo/TransactionType.java
+++ b/backend/src/main/java/dev/cuong/payment/domain/vo/TransactionType.java
@@ -1,0 +1,7 @@
+package dev.cuong.payment.domain.vo;
+
+public enum TransactionType {
+    PAYMENT,
+    DEPOSIT,
+    TRANSFER
+}

--- a/backend/src/main/java/dev/cuong/payment/domain/vo/UserRole.java
+++ b/backend/src/main/java/dev/cuong/payment/domain/vo/UserRole.java
@@ -1,0 +1,6 @@
+package dev.cuong.payment.domain.vo;
+
+public enum UserRole {
+    USER,
+    ADMIN
+}

--- a/backend/src/test/java/dev/cuong/payment/domain/AccountDomainTest.java
+++ b/backend/src/test/java/dev/cuong/payment/domain/AccountDomainTest.java
@@ -1,0 +1,107 @@
+package dev.cuong.payment.domain;
+
+import dev.cuong.payment.domain.exception.InsufficientFundsException;
+import dev.cuong.payment.domain.model.Account;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class AccountDomainTest {
+
+    // ── Debit ────────────────────────────────────────────────────────────────
+
+    @Test
+    void should_reduce_balance_when_debiting_valid_amount() {
+        Account account = accountWithBalance("500.00");
+
+        account.debit(new BigDecimal("200.00"));
+
+        assertThat(account.getBalance()).isEqualByComparingTo("300.00");
+    }
+
+    @Test
+    void should_allow_debiting_entire_balance() {
+        Account account = accountWithBalance("100.00");
+
+        account.debit(new BigDecimal("100.00"));
+
+        assertThat(account.getBalance()).isEqualByComparingTo("0.00");
+    }
+
+    @Test
+    void should_throw_when_debit_amount_exceeds_balance() {
+        Account account = accountWithBalance("100.00");
+
+        assertThatThrownBy(() -> account.debit(new BigDecimal("100.01")))
+                .isInstanceOf(InsufficientFundsException.class)
+                .hasMessageContaining("Insufficient funds");
+    }
+
+    @Test
+    void should_include_balance_and_requested_in_exception() {
+        UUID userId = UUID.randomUUID();
+        Account account = accountWithUserId(userId, "50.00");
+
+        InsufficientFundsException ex = (InsufficientFundsException)
+                org.assertj.core.api.Assertions.catchThrowable(
+                        () -> account.debit(new BigDecimal("75.00")));
+
+        assertThat(ex.getUserId()).isEqualTo(userId);
+        assertThat(ex.getBalance()).isEqualByComparingTo("50.00");
+        assertThat(ex.getRequested()).isEqualByComparingTo("75.00");
+    }
+
+    @Test
+    void should_update_timestamp_after_debit() {
+        Account account = accountWithBalance("200.00");
+        Instant before = Instant.now();
+
+        account.debit(new BigDecimal("50.00"));
+
+        assertThat(account.getUpdatedAt()).isAfterOrEqualTo(before);
+    }
+
+    // ── Credit ───────────────────────────────────────────────────────────────
+
+    @Test
+    void should_increase_balance_when_crediting() {
+        Account account = accountWithBalance("100.00");
+
+        account.credit(new BigDecimal("50.00"));
+
+        assertThat(account.getBalance()).isEqualByComparingTo("150.00");
+    }
+
+    @Test
+    void should_update_timestamp_after_credit() {
+        Account account = accountWithBalance("100.00");
+        Instant before = Instant.now();
+
+        account.credit(new BigDecimal("25.00"));
+
+        assertThat(account.getUpdatedAt()).isAfterOrEqualTo(before);
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private Account accountWithBalance(String balance) {
+        return accountWithUserId(UUID.randomUUID(), balance);
+    }
+
+    private Account accountWithUserId(UUID userId, String balance) {
+        return Account.builder()
+                .id(UUID.randomUUID())
+                .userId(userId)
+                .balance(new BigDecimal(balance))
+                .currency("USD")
+                .version(0L)
+                .createdAt(Instant.now())
+                .updatedAt(Instant.now())
+                .build();
+    }
+}

--- a/backend/src/test/java/dev/cuong/payment/domain/TransactionStateMachineTest.java
+++ b/backend/src/test/java/dev/cuong/payment/domain/TransactionStateMachineTest.java
@@ -1,0 +1,166 @@
+package dev.cuong.payment.domain;
+
+import dev.cuong.payment.domain.exception.InvalidTransactionStateException;
+import dev.cuong.payment.domain.model.Transaction;
+import dev.cuong.payment.domain.vo.TransactionStatus;
+import dev.cuong.payment.domain.vo.TransactionType;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class TransactionStateMachineTest {
+
+    // ── Valid transitions ────────────────────────────────────────────────────
+
+    @Test
+    void should_transition_to_processing_when_pending() {
+        Transaction tx = pendingTransaction();
+
+        tx.startProcessing();
+
+        assertThat(tx.getStatus()).isEqualTo(TransactionStatus.PROCESSING);
+    }
+
+    @Test
+    void should_transition_to_success_and_record_gateway_ref_when_processing() {
+        Transaction tx = pendingTransaction();
+        tx.startProcessing();
+
+        tx.complete("GW-REF-12345");
+
+        assertThat(tx.getStatus()).isEqualTo(TransactionStatus.SUCCESS);
+        assertThat(tx.getGatewayReference()).isEqualTo("GW-REF-12345");
+        assertThat(tx.getProcessedAt()).isNotNull();
+    }
+
+    @Test
+    void should_transition_to_failed_and_record_reason_when_processing() {
+        Transaction tx = pendingTransaction();
+        tx.startProcessing();
+
+        tx.fail("Payment gateway timeout");
+
+        assertThat(tx.getStatus()).isEqualTo(TransactionStatus.FAILED);
+        assertThat(tx.getFailureReason()).isEqualTo("Payment gateway timeout");
+    }
+
+    @Test
+    void should_transition_to_timeout_when_processing() {
+        Transaction tx = pendingTransaction();
+        tx.startProcessing();
+
+        tx.timeout();
+
+        assertThat(tx.getStatus()).isEqualTo(TransactionStatus.TIMEOUT);
+    }
+
+    @Test
+    void should_transition_to_refunded_and_record_timestamp_when_success() {
+        Transaction tx = pendingTransaction();
+        tx.startProcessing();
+        tx.complete("GW-REF-99");
+
+        tx.refund();
+
+        assertThat(tx.getStatus()).isEqualTo(TransactionStatus.REFUNDED);
+        assertThat(tx.getRefundedAt()).isNotNull();
+    }
+
+    // ── Invalid transitions ──────────────────────────────────────────────────
+
+    @Test
+    void should_reject_transition_from_pending_to_success() {
+        Transaction tx = pendingTransaction();
+
+        assertThatThrownBy(() -> tx.complete("GW-REF"))
+                .isInstanceOf(InvalidTransactionStateException.class)
+                .hasMessageContaining("PENDING")
+                .hasMessageContaining("SUCCESS");
+    }
+
+    @Test
+    void should_reject_refund_when_not_success() {
+        Transaction tx = pendingTransaction();
+        tx.startProcessing();
+        tx.fail("Declined");
+
+        assertThatThrownBy(tx::refund)
+                .isInstanceOf(InvalidTransactionStateException.class)
+                .hasMessageContaining("FAILED")
+                .hasMessageContaining("REFUNDED");
+    }
+
+    @Test
+    void should_reject_processing_when_already_processing() {
+        Transaction tx = pendingTransaction();
+        tx.startProcessing();
+
+        assertThatThrownBy(tx::startProcessing)
+                .isInstanceOf(InvalidTransactionStateException.class)
+                .hasMessageContaining("PROCESSING");
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = TransactionStatus.class, names = {"FAILED", "TIMEOUT", "REFUNDED"})
+    void should_reject_all_transitions_from_terminal_states(TransactionStatus terminal) {
+        assertThatThrownBy(() -> terminal.transitionTo(TransactionStatus.PENDING))
+                .isInstanceOf(InvalidTransactionStateException.class);
+        assertThatThrownBy(() -> terminal.transitionTo(TransactionStatus.PROCESSING))
+                .isInstanceOf(InvalidTransactionStateException.class);
+    }
+
+    // ── State introspection ──────────────────────────────────────────────────
+
+    @Test
+    void should_identify_terminal_states() {
+        assertThat(TransactionStatus.FAILED.isTerminal()).isTrue();
+        assertThat(TransactionStatus.TIMEOUT.isTerminal()).isTrue();
+        assertThat(TransactionStatus.REFUNDED.isTerminal()).isTrue();
+        assertThat(TransactionStatus.PENDING.isTerminal()).isFalse();
+        assertThat(TransactionStatus.PROCESSING.isTerminal()).isFalse();
+        assertThat(TransactionStatus.SUCCESS.isTerminal()).isFalse();
+    }
+
+    @Test
+    void should_flag_only_success_as_refundable() {
+        assertThat(TransactionStatus.SUCCESS.canBeRefunded()).isTrue();
+        assertThat(TransactionStatus.PENDING.canBeRefunded()).isFalse();
+        assertThat(TransactionStatus.PROCESSING.canBeRefunded()).isFalse();
+        assertThat(TransactionStatus.FAILED.canBeRefunded()).isFalse();
+        assertThat(TransactionStatus.TIMEOUT.canBeRefunded()).isFalse();
+        assertThat(TransactionStatus.REFUNDED.canBeRefunded()).isFalse();
+    }
+
+    @Test
+    void should_expose_from_and_to_in_exception() {
+        InvalidTransactionStateException ex = new InvalidTransactionStateException(
+                TransactionStatus.FAILED, TransactionStatus.PENDING);
+
+        assertThat(ex.getFrom()).isEqualTo(TransactionStatus.FAILED);
+        assertThat(ex.getTo()).isEqualTo(TransactionStatus.PENDING);
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private Transaction pendingTransaction() {
+        return Transaction.builder()
+                .id(UUID.randomUUID())
+                .userId(UUID.randomUUID())
+                .accountId(UUID.randomUUID())
+                .amount(new BigDecimal("100.00"))
+                .currency("USD")
+                .type(TransactionType.PAYMENT)
+                .status(TransactionStatus.PENDING)
+                .createdAt(Instant.now())
+                .updatedAt(Instant.now())
+                .build();
+    }
+
+}


### PR DESCRIPTION
## What this PR does
Closes #5

Introduces the domain layer - the innermost ring of the hexagonal architecture.
All three aggregate roots (User, Account, Transaction) are plain Java with zero
framework imports; Lombok handles builder/getter boilerplate at compile time only.
The state machine lives inside the TransactionStatus enum itself: calling
transitionTo() on a terminal state throws InvalidTransactionStateException
immediately, making ledger corruption structurally impossible.

## How to test
1. cd backend
2. ./gradlew test --tests "dev.cuong.payment.domain.*"
   Expected: BUILD SUCCESSFUL, 21 tests, 0 failures, <500ms total
3. Confirm no Spring context started (no "Started application" log line in output)

## Technical decisions
- State machine lives in the enum, not a service: validation is co-located with
  the thing being validated. A separate TransactionStateValidator class would
  require callers to remember to call it - the enum approach makes it impossible
  to skip.
- Lombok on domain objects: Lombok is a compile-time code generator with zero
  runtime footprint. This does not violate the "no framework dependencies in
  domain" rule - there is no Lombok jar on the runtime classpath.
- DomainException as abstract base: the presentation layer can catch DomainException
  in one @ExceptionHandler and map all subclasses to HTTP status codes without
  knowing about individual exception types.