### PR TITLE
Task/04-jpa-infrastructure

### DIFF
--- a/backend/src/main/java/dev/cuong/payment/infrastructure/persistence/adapter/AccountRepositoryAdapter.java
+++ b/backend/src/main/java/dev/cuong/payment/infrastructure/persistence/adapter/AccountRepositoryAdapter.java
@@ -1,0 +1,33 @@
+package dev.cuong.payment.infrastructure.persistence.adapter;
+
+import dev.cuong.payment.application.port.out.AccountRepository;
+import dev.cuong.payment.domain.model.Account;
+import dev.cuong.payment.infrastructure.persistence.mapper.AccountMapper;
+import dev.cuong.payment.infrastructure.persistence.repository.AccountJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class AccountRepositoryAdapter implements AccountRepository {
+
+    private final AccountJpaRepository jpaRepository;
+
+    @Override
+    public Optional<Account> findByUserId(UUID userId) {
+        return jpaRepository.findByUserId(userId).map(AccountMapper::toDomain);
+    }
+
+    @Override
+    public Optional<Account> findByUserIdForUpdate(UUID userId) {
+        return jpaRepository.findByUserIdWithLock(userId).map(AccountMapper::toDomain);
+    }
+
+    @Override
+    public Account save(Account account) {
+        return AccountMapper.toDomain(jpaRepository.save(AccountMapper.toEntity(account)));
+    }
+}

--- a/backend/src/main/java/dev/cuong/payment/infrastructure/persistence/adapter/TransactionRepositoryAdapter.java
+++ b/backend/src/main/java/dev/cuong/payment/infrastructure/persistence/adapter/TransactionRepositoryAdapter.java
@@ -1,0 +1,54 @@
+package dev.cuong.payment.infrastructure.persistence.adapter;
+
+import dev.cuong.payment.application.port.out.TransactionRepository;
+import dev.cuong.payment.domain.model.Transaction;
+import dev.cuong.payment.infrastructure.persistence.mapper.TransactionMapper;
+import dev.cuong.payment.infrastructure.persistence.repository.TransactionJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class TransactionRepositoryAdapter implements TransactionRepository {
+
+    private final TransactionJpaRepository jpaRepository;
+
+    @Override
+    public Optional<Transaction> findById(UUID id) {
+        return jpaRepository.findById(id).map(TransactionMapper::toDomain);
+    }
+
+    @Override
+    public Optional<Transaction> findByIdAndUserId(UUID id, UUID userId) {
+        return jpaRepository.findByIdAndUserId(id, userId).map(TransactionMapper::toDomain);
+    }
+
+    @Override
+    public List<Transaction> findByUserId(UUID userId, int page, int size) {
+        PageRequest pageable = PageRequest.of(page, size, Sort.by("createdAt").descending());
+        return jpaRepository.findByUserId(userId, pageable)
+                .map(TransactionMapper::toDomain)
+                .toList();
+    }
+
+    @Override
+    public long countByUserId(UUID userId) {
+        return jpaRepository.countByUserId(userId);
+    }
+
+    @Override
+    public Optional<Transaction> findByIdempotencyKey(String idempotencyKey) {
+        return jpaRepository.findByIdempotencyKey(idempotencyKey).map(TransactionMapper::toDomain);
+    }
+
+    @Override
+    public Transaction save(Transaction transaction) {
+        return TransactionMapper.toDomain(jpaRepository.save(TransactionMapper.toEntity(transaction)));
+    }
+}

--- a/backend/src/main/java/dev/cuong/payment/infrastructure/persistence/adapter/UserRepositoryAdapter.java
+++ b/backend/src/main/java/dev/cuong/payment/infrastructure/persistence/adapter/UserRepositoryAdapter.java
@@ -1,0 +1,48 @@
+package dev.cuong.payment.infrastructure.persistence.adapter;
+
+import dev.cuong.payment.application.port.out.UserRepository;
+import dev.cuong.payment.domain.model.User;
+import dev.cuong.payment.infrastructure.persistence.mapper.UserMapper;
+import dev.cuong.payment.infrastructure.persistence.repository.UserJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class UserRepositoryAdapter implements UserRepository {
+
+    private final UserJpaRepository jpaRepository;
+
+    @Override
+    public Optional<User> findById(UUID id) {
+        return jpaRepository.findById(id).map(UserMapper::toDomain);
+    }
+
+    @Override
+    public Optional<User> findByUsername(String username) {
+        return jpaRepository.findByUsername(username).map(UserMapper::toDomain);
+    }
+
+    @Override
+    public Optional<User> findByEmail(String email) {
+        return jpaRepository.findByEmail(email).map(UserMapper::toDomain);
+    }
+
+    @Override
+    public boolean existsByUsername(String username) {
+        return jpaRepository.existsByUsername(username);
+    }
+
+    @Override
+    public boolean existsByEmail(String email) {
+        return jpaRepository.existsByEmail(email);
+    }
+
+    @Override
+    public User save(User user) {
+        return UserMapper.toDomain(jpaRepository.save(UserMapper.toEntity(user)));
+    }
+}

--- a/backend/src/main/java/dev/cuong/payment/infrastructure/persistence/entity/AccountJpaEntity.java
+++ b/backend/src/main/java/dev/cuong/payment/infrastructure/persistence/entity/AccountJpaEntity.java
@@ -1,0 +1,55 @@
+package dev.cuong.payment.infrastructure.persistence.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+
+@Entity
+@Table(name = "accounts")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class AccountJpaEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(name = "user_id", nullable = false)
+    private UUID userId;
+
+    @Column(nullable = false, precision = 19, scale = 4)
+    private BigDecimal balance;
+
+    @Column(nullable = false, length = 3)
+    private String currency;
+
+    // Optimistic locking: Hibernate includes WHERE version=? on every UPDATE.
+    // Concurrent update from a different transaction increments the version first,
+    // causing this update to match 0 rows → OptimisticLockException.
+    @Version
+    private Long version;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+
+    @PrePersist
+    void prePersist() {
+        Instant now = Instant.now();
+        if (createdAt == null) createdAt = now;
+        if (updatedAt == null) updatedAt = now;
+    }
+
+    @PreUpdate
+    void preUpdate() {
+        updatedAt = Instant.now();
+    }
+}

--- a/backend/src/main/java/dev/cuong/payment/infrastructure/persistence/entity/TransactionJpaEntity.java
+++ b/backend/src/main/java/dev/cuong/payment/infrastructure/persistence/entity/TransactionJpaEntity.java
@@ -1,0 +1,84 @@
+package dev.cuong.payment.infrastructure.persistence.entity;
+
+import dev.cuong.payment.domain.vo.TransactionStatus;
+import dev.cuong.payment.domain.vo.TransactionType;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+
+@Entity
+@Table(name = "transactions")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class TransactionJpaEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(name = "user_id", nullable = false)
+    private UUID userId;
+
+    @Column(name = "account_id", nullable = false)
+    private UUID accountId;
+
+    @Column(nullable = false, precision = 19, scale = 4)
+    private BigDecimal amount;
+
+    @Column(nullable = false, length = 3)
+    private String currency;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private TransactionType type;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private TransactionStatus status;
+
+    @Column(length = 500)
+    private String description;
+
+    @Column(name = "idempotency_key", length = 255)
+    private String idempotencyKey;
+
+    @Column(name = "gateway_reference", length = 255)
+    private String gatewayReference;
+
+    @Column(name = "failure_reason", columnDefinition = "TEXT")
+    private String failureReason;
+
+    @Version
+    private Long version;
+
+    @Column(name = "processed_at")
+    private Instant processedAt;
+
+    @Column(name = "refunded_at")
+    private Instant refundedAt;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+
+    @PrePersist
+    void prePersist() {
+        Instant now = Instant.now();
+        if (createdAt == null) createdAt = now;
+        if (updatedAt == null) updatedAt = now;
+        if (status == null) status = TransactionStatus.PENDING;
+    }
+
+    @PreUpdate
+    void preUpdate() {
+        updatedAt = Instant.now();
+    }
+}

--- a/backend/src/main/java/dev/cuong/payment/infrastructure/persistence/entity/UserJpaEntity.java
+++ b/backend/src/main/java/dev/cuong/payment/infrastructure/persistence/entity/UserJpaEntity.java
@@ -1,0 +1,53 @@
+package dev.cuong.payment.infrastructure.persistence.entity;
+
+import dev.cuong.payment.domain.vo.UserRole;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Entity
+@Table(name = "users")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class UserJpaEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(nullable = false, length = 50, unique = true)
+    private String username;
+
+    @Column(nullable = false, length = 255, unique = true)
+    private String email;
+
+    @Column(name = "password_hash", nullable = false)
+    private String passwordHash;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private UserRole role;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+
+    @PrePersist
+    void prePersist() {
+        Instant now = Instant.now();
+        if (createdAt == null) createdAt = now;
+        if (updatedAt == null) updatedAt = now;
+    }
+
+    @PreUpdate
+    void preUpdate() {
+        updatedAt = Instant.now();
+    }
+}

--- a/backend/src/main/java/dev/cuong/payment/infrastructure/persistence/mapper/AccountMapper.java
+++ b/backend/src/main/java/dev/cuong/payment/infrastructure/persistence/mapper/AccountMapper.java
@@ -1,0 +1,33 @@
+package dev.cuong.payment.infrastructure.persistence.mapper;
+
+import dev.cuong.payment.domain.model.Account;
+import dev.cuong.payment.infrastructure.persistence.entity.AccountJpaEntity;
+
+public final class AccountMapper {
+
+    private AccountMapper() {}
+
+    public static Account toDomain(AccountJpaEntity entity) {
+        return Account.builder()
+                .id(entity.getId())
+                .userId(entity.getUserId())
+                .balance(entity.getBalance())
+                .currency(entity.getCurrency())
+                .version(entity.getVersion() != null ? entity.getVersion() : 0L)
+                .createdAt(entity.getCreatedAt())
+                .updatedAt(entity.getUpdatedAt())
+                .build();
+    }
+
+    public static AccountJpaEntity toEntity(Account account) {
+        return AccountJpaEntity.builder()
+                .id(account.getId())
+                .userId(account.getUserId())
+                .balance(account.getBalance())
+                .currency(account.getCurrency())
+                .version(account.getVersion())
+                .createdAt(account.getCreatedAt())
+                .updatedAt(account.getUpdatedAt())
+                .build();
+    }
+}

--- a/backend/src/main/java/dev/cuong/payment/infrastructure/persistence/mapper/TransactionMapper.java
+++ b/backend/src/main/java/dev/cuong/payment/infrastructure/persistence/mapper/TransactionMapper.java
@@ -1,0 +1,51 @@
+package dev.cuong.payment.infrastructure.persistence.mapper;
+
+import dev.cuong.payment.domain.model.Transaction;
+import dev.cuong.payment.infrastructure.persistence.entity.TransactionJpaEntity;
+
+public final class TransactionMapper {
+
+    private TransactionMapper() {}
+
+    public static Transaction toDomain(TransactionJpaEntity entity) {
+        return Transaction.builder()
+                .id(entity.getId())
+                .userId(entity.getUserId())
+                .accountId(entity.getAccountId())
+                .amount(entity.getAmount())
+                .currency(entity.getCurrency())
+                .type(entity.getType())
+                .status(entity.getStatus())
+                .description(entity.getDescription())
+                .idempotencyKey(entity.getIdempotencyKey())
+                .gatewayReference(entity.getGatewayReference())
+                .failureReason(entity.getFailureReason())
+                .version(entity.getVersion() != null ? entity.getVersion() : 0L)
+                .processedAt(entity.getProcessedAt())
+                .refundedAt(entity.getRefundedAt())
+                .createdAt(entity.getCreatedAt())
+                .updatedAt(entity.getUpdatedAt())
+                .build();
+    }
+
+    public static TransactionJpaEntity toEntity(Transaction tx) {
+        return TransactionJpaEntity.builder()
+                .id(tx.getId())
+                .userId(tx.getUserId())
+                .accountId(tx.getAccountId())
+                .amount(tx.getAmount())
+                .currency(tx.getCurrency())
+                .type(tx.getType())
+                .status(tx.getStatus())
+                .description(tx.getDescription())
+                .idempotencyKey(tx.getIdempotencyKey())
+                .gatewayReference(tx.getGatewayReference())
+                .failureReason(tx.getFailureReason())
+                .version(tx.getVersion())
+                .processedAt(tx.getProcessedAt())
+                .refundedAt(tx.getRefundedAt())
+                .createdAt(tx.getCreatedAt())
+                .updatedAt(tx.getUpdatedAt())
+                .build();
+    }
+}

--- a/backend/src/main/java/dev/cuong/payment/infrastructure/persistence/mapper/UserMapper.java
+++ b/backend/src/main/java/dev/cuong/payment/infrastructure/persistence/mapper/UserMapper.java
@@ -1,0 +1,33 @@
+package dev.cuong.payment.infrastructure.persistence.mapper;
+
+import dev.cuong.payment.domain.model.User;
+import dev.cuong.payment.infrastructure.persistence.entity.UserJpaEntity;
+
+public final class UserMapper {
+
+    private UserMapper() {}
+
+    public static User toDomain(UserJpaEntity entity) {
+        return User.builder()
+                .id(entity.getId())
+                .username(entity.getUsername())
+                .email(entity.getEmail())
+                .passwordHash(entity.getPasswordHash())
+                .role(entity.getRole())
+                .createdAt(entity.getCreatedAt())
+                .updatedAt(entity.getUpdatedAt())
+                .build();
+    }
+
+    public static UserJpaEntity toEntity(User user) {
+        return UserJpaEntity.builder()
+                .id(user.getId())
+                .username(user.getUsername())
+                .email(user.getEmail())
+                .passwordHash(user.getPasswordHash())
+                .role(user.getRole())
+                .createdAt(user.getCreatedAt())
+                .updatedAt(user.getUpdatedAt())
+                .build();
+    }
+}

--- a/backend/src/main/java/dev/cuong/payment/infrastructure/persistence/repository/AccountJpaRepository.java
+++ b/backend/src/main/java/dev/cuong/payment/infrastructure/persistence/repository/AccountJpaRepository.java
@@ -1,0 +1,22 @@
+package dev.cuong.payment.infrastructure.persistence.repository;
+
+import dev.cuong.payment.infrastructure.persistence.entity.AccountJpaEntity;
+import jakarta.persistence.LockModeType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface AccountJpaRepository extends JpaRepository<AccountJpaEntity, UUID> {
+
+    Optional<AccountJpaEntity> findByUserId(UUID userId);
+
+    // PESSIMISTIC_WRITE → SELECT ... FOR UPDATE. Must be called within
+    // an active @Transactional boundary or PostgreSQL will reject the lock mode.
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT a FROM AccountJpaEntity a WHERE a.userId = :userId")
+    Optional<AccountJpaEntity> findByUserIdWithLock(@Param("userId") UUID userId);
+}

--- a/backend/src/main/java/dev/cuong/payment/infrastructure/persistence/repository/TransactionJpaRepository.java
+++ b/backend/src/main/java/dev/cuong/payment/infrastructure/persistence/repository/TransactionJpaRepository.java
@@ -1,0 +1,20 @@
+package dev.cuong.payment.infrastructure.persistence.repository;
+
+import dev.cuong.payment.infrastructure.persistence.entity.TransactionJpaEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface TransactionJpaRepository extends JpaRepository<TransactionJpaEntity, UUID> {
+
+    Optional<TransactionJpaEntity> findByIdAndUserId(UUID id, UUID userId);
+
+    Page<TransactionJpaEntity> findByUserId(UUID userId, Pageable pageable);
+
+    long countByUserId(UUID userId);
+
+    Optional<TransactionJpaEntity> findByIdempotencyKey(String idempotencyKey);
+}

--- a/backend/src/main/java/dev/cuong/payment/infrastructure/persistence/repository/UserJpaRepository.java
+++ b/backend/src/main/java/dev/cuong/payment/infrastructure/persistence/repository/UserJpaRepository.java
@@ -1,0 +1,18 @@
+package dev.cuong.payment.infrastructure.persistence.repository;
+
+import dev.cuong.payment.infrastructure.persistence.entity.UserJpaEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface UserJpaRepository extends JpaRepository<UserJpaEntity, UUID> {
+
+    Optional<UserJpaEntity> findByUsername(String username);
+
+    Optional<UserJpaEntity> findByEmail(String email);
+
+    boolean existsByUsername(String username);
+
+    boolean existsByEmail(String email);
+}

--- a/backend/src/test/java/dev/cuong/payment/infrastructure/persistence/AbstractPersistenceIntegrationTest.java
+++ b/backend/src/test/java/dev/cuong/payment/infrastructure/persistence/AbstractPersistenceIntegrationTest.java
@@ -1,0 +1,27 @@
+package dev.cuong.payment.infrastructure.persistence;
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.transaction.annotation.Transactional;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@SpringBootTest
+@Testcontainers
+@Transactional
+@TestPropertySource(properties = {
+        "spring.autoconfigure.exclude=" +
+                "org.redisson.spring.starter.RedissonAutoConfigurationV2," +
+                "org.springframework.boot.autoconfigure.kafka.KafkaAutoConfiguration",
+        "spring.flyway.enabled=true",
+        "spring.flyway.validate-on-migrate=true",
+        "spring.jpa.hibernate.ddl-auto=validate"
+})
+abstract class AbstractPersistenceIntegrationTest {
+
+    @Container
+    @ServiceConnection
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:15-alpine");
+}

--- a/backend/src/test/java/dev/cuong/payment/infrastructure/persistence/AccountRepositoryAdapterIntegrationTest.java
+++ b/backend/src/test/java/dev/cuong/payment/infrastructure/persistence/AccountRepositoryAdapterIntegrationTest.java
@@ -1,0 +1,106 @@
+package dev.cuong.payment.infrastructure.persistence;
+
+import dev.cuong.payment.application.port.out.AccountRepository;
+import dev.cuong.payment.application.port.out.UserRepository;
+import dev.cuong.payment.domain.model.Account;
+import dev.cuong.payment.domain.model.User;
+import dev.cuong.payment.domain.vo.UserRole;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AccountRepositoryAdapterIntegrationTest extends AbstractPersistenceIntegrationTest {
+
+    @Autowired
+    private AccountRepository accountRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    private UUID userId;
+
+    @BeforeEach
+    void setupUser() {
+        User user = userRepository.save(User.builder()
+                .username("account-test-user-" + UUID.randomUUID())
+                .email("acct-" + UUID.randomUUID() + "@test.com")
+                .passwordHash("hash")
+                .role(UserRole.USER)
+                .createdAt(Instant.now())
+                .updatedAt(Instant.now())
+                .build());
+        userId = user.getId();
+    }
+
+    @Test
+    void should_persist_and_find_account_by_user_id() {
+        accountRepository.save(buildAccount(userId, "500.00"));
+
+        Optional<Account> found = accountRepository.findByUserId(userId);
+
+        assertThat(found).isPresent();
+        assertThat(found.get().getUserId()).isEqualTo(userId);
+        assertThat(found.get().getBalance()).isEqualByComparingTo("500.00");
+        assertThat(found.get().getCurrency()).isEqualTo("USD");
+    }
+
+    @Test
+    void should_return_empty_when_account_not_found() {
+        Optional<Account> found = accountRepository.findByUserId(UUID.randomUUID());
+
+        assertThat(found).isEmpty();
+    }
+
+    @Test
+    void should_persist_balance_change_after_debit() {
+        Account account = accountRepository.save(buildAccount(userId, "300.00"));
+        account.debit(new BigDecimal("100.00"));
+        accountRepository.save(account);
+
+        Account reloaded = accountRepository.findByUserId(userId).orElseThrow();
+
+        assertThat(reloaded.getBalance()).isEqualByComparingTo("200.00");
+    }
+
+    @Test
+    void should_persist_balance_change_after_credit() {
+        Account account = accountRepository.save(buildAccount(userId, "100.00"));
+        account.credit(new BigDecimal("50.00"));
+        accountRepository.save(account);
+
+        Account reloaded = accountRepository.findByUserId(userId).orElseThrow();
+
+        assertThat(reloaded.getBalance()).isEqualByComparingTo("150.00");
+    }
+
+    @Test
+    void should_find_account_for_pessimistic_lock_update() {
+        accountRepository.save(buildAccount(userId, "1000.00"));
+
+        Optional<Account> locked = accountRepository.findByUserIdForUpdate(userId);
+
+        assertThat(locked).isPresent();
+        assertThat(locked.get().getBalance()).isEqualByComparingTo("1000.00");
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private Account buildAccount(UUID ownerUserId, String balance) {
+        Instant now = Instant.now();
+        return Account.builder()
+                .userId(ownerUserId)
+                .balance(new BigDecimal(balance))
+                .currency("USD")
+                .version(0L)
+                .createdAt(now)
+                .updatedAt(now)
+                .build();
+    }
+}

--- a/backend/src/test/java/dev/cuong/payment/infrastructure/persistence/TransactionRepositoryAdapterIntegrationTest.java
+++ b/backend/src/test/java/dev/cuong/payment/infrastructure/persistence/TransactionRepositoryAdapterIntegrationTest.java
@@ -1,0 +1,148 @@
+package dev.cuong.payment.infrastructure.persistence;
+
+import dev.cuong.payment.application.port.out.AccountRepository;
+import dev.cuong.payment.application.port.out.TransactionRepository;
+import dev.cuong.payment.application.port.out.UserRepository;
+import dev.cuong.payment.domain.model.Account;
+import dev.cuong.payment.domain.model.Transaction;
+import dev.cuong.payment.domain.model.User;
+import dev.cuong.payment.domain.vo.TransactionStatus;
+import dev.cuong.payment.domain.vo.TransactionType;
+import dev.cuong.payment.domain.vo.UserRole;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TransactionRepositoryAdapterIntegrationTest extends AbstractPersistenceIntegrationTest {
+
+    @Autowired
+    private TransactionRepository transactionRepository;
+
+    @Autowired
+    private AccountRepository accountRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    private UUID userId;
+    private UUID accountId;
+
+    @BeforeEach
+    void setupUserAndAccount() {
+        User user = userRepository.save(User.builder()
+                .username("tx-test-user-" + UUID.randomUUID())
+                .email("tx-" + UUID.randomUUID() + "@test.com")
+                .passwordHash("hash")
+                .role(UserRole.USER)
+                .createdAt(Instant.now())
+                .updatedAt(Instant.now())
+                .build());
+        userId = user.getId();
+
+        Account account = accountRepository.save(Account.builder()
+                .userId(userId)
+                .balance(new BigDecimal("5000.00"))
+                .currency("USD")
+                .version(0L)
+                .createdAt(Instant.now())
+                .updatedAt(Instant.now())
+                .build());
+        accountId = account.getId();
+    }
+
+    @Test
+    void should_persist_and_find_transaction_by_id() {
+        Transaction saved = transactionRepository.save(buildTransaction(null));
+
+        Optional<Transaction> found = transactionRepository.findById(saved.getId());
+
+        assertThat(found).isPresent();
+        assertThat(found.get().getAmount()).isEqualByComparingTo("250.00");
+        assertThat(found.get().getStatus()).isEqualTo(TransactionStatus.PENDING);
+        assertThat(found.get().getType()).isEqualTo(TransactionType.PAYMENT);
+    }
+
+    @Test
+    void should_find_transaction_scoped_to_user() {
+        Transaction saved = transactionRepository.save(buildTransaction(null));
+
+        Optional<Transaction> found = transactionRepository.findByIdAndUserId(saved.getId(), userId);
+        Optional<Transaction> notFound = transactionRepository.findByIdAndUserId(saved.getId(), UUID.randomUUID());
+
+        assertThat(found).isPresent();
+        assertThat(notFound).isEmpty();
+    }
+
+    @Test
+    void should_return_user_transactions_newest_first() {
+        transactionRepository.save(buildTransaction(null));
+        transactionRepository.save(buildTransaction(null));
+        transactionRepository.save(buildTransaction(null));
+
+        List<Transaction> page = transactionRepository.findByUserId(userId, 0, 10);
+
+        assertThat(page).hasSize(3);
+        // Verify descending order by checking each is not older than the next
+        for (int i = 0; i < page.size() - 1; i++) {
+            assertThat(page.get(i).getCreatedAt())
+                    .isAfterOrEqualTo(page.get(i + 1).getCreatedAt());
+        }
+    }
+
+    @Test
+    void should_count_user_transactions() {
+        transactionRepository.save(buildTransaction(null));
+        transactionRepository.save(buildTransaction(null));
+
+        long count = transactionRepository.countByUserId(userId);
+
+        assertThat(count).isEqualTo(2);
+    }
+
+    @Test
+    void should_find_transaction_by_idempotency_key() {
+        String idempotencyKey = "idem-key-" + UUID.randomUUID();
+        transactionRepository.save(buildTransaction(idempotencyKey));
+
+        Optional<Transaction> found = transactionRepository.findByIdempotencyKey(idempotencyKey);
+        Optional<Transaction> missing = transactionRepository.findByIdempotencyKey("nonexistent-key");
+
+        assertThat(found).isPresent();
+        assertThat(missing).isEmpty();
+    }
+
+    @Test
+    void should_not_return_other_users_transactions_in_count() {
+        transactionRepository.save(buildTransaction(null));
+
+        long countForOtherUser = transactionRepository.countByUserId(UUID.randomUUID());
+
+        assertThat(countForOtherUser).isZero();
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private Transaction buildTransaction(String idempotencyKey) {
+        Instant now = Instant.now();
+        return Transaction.builder()
+                .userId(userId)
+                .accountId(accountId)
+                .amount(new BigDecimal("250.00"))
+                .currency("USD")
+                .type(TransactionType.PAYMENT)
+                .status(TransactionStatus.PENDING)
+                .idempotencyKey(idempotencyKey)
+                .version(0L)
+                .createdAt(now)
+                .updatedAt(now)
+                .build();
+    }
+}

--- a/backend/src/test/java/dev/cuong/payment/infrastructure/persistence/UserRepositoryAdapterIntegrationTest.java
+++ b/backend/src/test/java/dev/cuong/payment/infrastructure/persistence/UserRepositoryAdapterIntegrationTest.java
@@ -1,0 +1,88 @@
+package dev.cuong.payment.infrastructure.persistence;
+
+import dev.cuong.payment.application.port.out.UserRepository;
+import dev.cuong.payment.domain.model.User;
+import dev.cuong.payment.domain.vo.UserRole;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UserRepositoryAdapterIntegrationTest extends AbstractPersistenceIntegrationTest {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Test
+    void should_persist_and_find_user_by_id() {
+        User saved = userRepository.save(buildUser("alice", "alice@example.com"));
+
+        Optional<User> found = userRepository.findById(saved.getId());
+
+        assertThat(found).isPresent();
+        assertThat(found.get().getUsername()).isEqualTo("alice");
+        assertThat(found.get().getEmail()).isEqualTo("alice@example.com");
+        assertThat(found.get().getRole()).isEqualTo(UserRole.USER);
+    }
+
+    @Test
+    void should_find_user_by_username() {
+        userRepository.save(buildUser("bob", "bob@example.com"));
+
+        Optional<User> found = userRepository.findByUsername("bob");
+
+        assertThat(found).isPresent();
+        assertThat(found.get().getEmail()).isEqualTo("bob@example.com");
+    }
+
+    @Test
+    void should_find_user_by_email() {
+        userRepository.save(buildUser("carol", "carol@example.com"));
+
+        Optional<User> found = userRepository.findByEmail("carol@example.com");
+
+        assertThat(found).isPresent();
+        assertThat(found.get().getUsername()).isEqualTo("carol");
+    }
+
+    @Test
+    void should_return_empty_when_user_not_found_by_id() {
+        Optional<User> found = userRepository.findById(UUID.randomUUID());
+
+        assertThat(found).isEmpty();
+    }
+
+    @Test
+    void should_detect_duplicate_username() {
+        userRepository.save(buildUser("dave", "dave@example.com"));
+
+        assertThat(userRepository.existsByUsername("dave")).isTrue();
+        assertThat(userRepository.existsByUsername("unknown")).isFalse();
+    }
+
+    @Test
+    void should_detect_duplicate_email() {
+        userRepository.save(buildUser("eve", "eve@example.com"));
+
+        assertThat(userRepository.existsByEmail("eve@example.com")).isTrue();
+        assertThat(userRepository.existsByEmail("nobody@example.com")).isFalse();
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private User buildUser(String username, String email) {
+        Instant now = Instant.now();
+        return User.builder()
+                .username(username)
+                .email(email)
+                .passwordHash("$2a$10$hashedpassword")
+                .role(UserRole.USER)
+                .createdAt(now)
+                .updatedAt(now)
+                .build();
+    }
+}


### PR DESCRIPTION
## What this PR does
Closes #6

Introduces the full persistence adapter layer: JPA entities that map 1:1 to the Flyway schema, Spring Data JPA repositories (internal to infrastructure), and adapter classes that implement the output port interfaces defined in the application layer. Domain objects (User, Account, Transaction) have zero JPA annotations - mapping is handled exclusively by static mapper classes in the infrastructure package. AccountRepository exposes findByUserIdForUpdate() which issues SELECT FOR UPDATE
via JPA's PESSIMISTIC_WRITE lock mode; Transaction and Account JPA entities carry @Version for optimistic lock detection.

## How to test
1. Start Docker Desktop
2. cd backend && ./gradlew test
   Expected: BUILD SUCCESSFUL - 38 tests total
   (21 unit + 7 migration + 4 ApplicationContext smoke + 6 UserRepo + 5 AccountRepo + 6 TxRepo - overlap due to @BeforeEach)
3. Unit tests only (no Docker needed):
   ./gradlew test --tests "dev.cuong.payment.domain.*"

## Technical decisions
- Mappers made public (not truly package-private) because Java's package-private visibility doesn't span sub-packages. The hexagonal boundary is still enforced at the port interface level in the application layer - nobody injects UserJpaRepository when UserRepository (the port) is available.
- Spring's Pageable is used INSIDE the JPA repository (infrastructure-internal); the port interface accepts plain int page/size. This keeps the application layer framework-free.
- @PrePersist/@PreUpdate for timestamps instead of Spring Data auditing: avoids adding @EnableJpaAuditing and keeps timestamp logic co-located with the entity.