### PR TITLE
Task/05-jwt-security

### DIFF
--- a/backend/src/main/java/dev/cuong/payment/application/dto/AuthResult.java
+++ b/backend/src/main/java/dev/cuong/payment/application/dto/AuthResult.java
@@ -1,0 +1,5 @@
+package dev.cuong.payment.application.dto;
+
+import java.util.UUID;
+
+public record AuthResult(String token, UUID userId, String username, String role) {}

--- a/backend/src/main/java/dev/cuong/payment/application/dto/LoginCommand.java
+++ b/backend/src/main/java/dev/cuong/payment/application/dto/LoginCommand.java
@@ -1,0 +1,3 @@
+package dev.cuong.payment.application.dto;
+
+public record LoginCommand(String username, String password) {}

--- a/backend/src/main/java/dev/cuong/payment/application/dto/RegisterUserCommand.java
+++ b/backend/src/main/java/dev/cuong/payment/application/dto/RegisterUserCommand.java
@@ -1,0 +1,3 @@
+package dev.cuong.payment.application.dto;
+
+public record RegisterUserCommand(String username, String email, String password) {}

--- a/backend/src/main/java/dev/cuong/payment/application/port/in/LoginUseCase.java
+++ b/backend/src/main/java/dev/cuong/payment/application/port/in/LoginUseCase.java
@@ -1,0 +1,13 @@
+package dev.cuong.payment.application.port.in;
+
+import dev.cuong.payment.application.dto.AuthResult;
+import dev.cuong.payment.application.dto.LoginCommand;
+
+/**
+ * Input port: user login.
+ * Validates credentials and returns a JWT on success.
+ */
+public interface LoginUseCase {
+
+    AuthResult login(LoginCommand command);
+}

--- a/backend/src/main/java/dev/cuong/payment/application/port/in/RegisterUserUseCase.java
+++ b/backend/src/main/java/dev/cuong/payment/application/port/in/RegisterUserUseCase.java
@@ -1,0 +1,13 @@
+package dev.cuong.payment.application.port.in;
+
+import dev.cuong.payment.application.dto.AuthResult;
+import dev.cuong.payment.application.dto.RegisterUserCommand;
+
+/**
+ * Input port: user registration.
+ * Validates uniqueness, hashes the password, persists the user, and returns a JWT.
+ */
+public interface RegisterUserUseCase {
+
+    AuthResult register(RegisterUserCommand command);
+}

--- a/backend/src/main/java/dev/cuong/payment/application/service/AuthApplicationService.java
+++ b/backend/src/main/java/dev/cuong/payment/application/service/AuthApplicationService.java
@@ -1,0 +1,74 @@
+package dev.cuong.payment.application.service;
+
+import dev.cuong.payment.application.dto.AuthResult;
+import dev.cuong.payment.application.dto.LoginCommand;
+import dev.cuong.payment.application.dto.RegisterUserCommand;
+import dev.cuong.payment.application.port.in.LoginUseCase;
+import dev.cuong.payment.application.port.in.RegisterUserUseCase;
+import dev.cuong.payment.application.port.out.UserRepository;
+import dev.cuong.payment.domain.exception.InvalidCredentialsException;
+import dev.cuong.payment.domain.exception.UserAlreadyExistsException;
+import dev.cuong.payment.domain.model.User;
+import dev.cuong.payment.domain.vo.UserRole;
+import dev.cuong.payment.infrastructure.security.JwtService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AuthApplicationService implements RegisterUserUseCase, LoginUseCase {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtService jwtService;
+
+    @Override
+    @Transactional
+    public AuthResult register(RegisterUserCommand command) {
+        if (userRepository.existsByUsername(command.username())) {
+            throw new UserAlreadyExistsException("username", command.username());
+        }
+        if (userRepository.existsByEmail(command.email())) {
+            throw new UserAlreadyExistsException("email", command.email());
+        }
+
+        Instant now = Instant.now();
+        User user = User.builder()
+                .username(command.username())
+                .email(command.email())
+                .passwordHash(passwordEncoder.encode(command.password()))
+                .role(UserRole.USER)
+                .createdAt(now)
+                .updatedAt(now)
+                .build();
+
+        User saved = userRepository.save(user);
+        String token = jwtService.generateToken(saved.getId(), saved.getUsername(), saved.getRole());
+
+        log.info("User registered: userId={}, username={}", saved.getId(), saved.getUsername());
+        return new AuthResult(token, saved.getId(), saved.getUsername(), saved.getRole().name());
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public AuthResult login(LoginCommand command) {
+        User user = userRepository.findByUsername(command.username())
+                .orElseThrow(InvalidCredentialsException::new);
+
+        if (!passwordEncoder.matches(command.password(), user.getPasswordHash())) {
+            // Intentionally same exception as "user not found" — prevents username enumeration
+            throw new InvalidCredentialsException();
+        }
+
+        String token = jwtService.generateToken(user.getId(), user.getUsername(), user.getRole());
+
+        log.info("User logged in: userId={}, username={}", user.getId(), user.getUsername());
+        return new AuthResult(token, user.getId(), user.getUsername(), user.getRole().name());
+    }
+}

--- a/backend/src/main/java/dev/cuong/payment/domain/exception/InvalidCredentialsException.java
+++ b/backend/src/main/java/dev/cuong/payment/domain/exception/InvalidCredentialsException.java
@@ -1,0 +1,8 @@
+package dev.cuong.payment.domain.exception;
+
+public class InvalidCredentialsException extends DomainException {
+
+    public InvalidCredentialsException() {
+        super("Invalid username or password");
+    }
+}

--- a/backend/src/main/java/dev/cuong/payment/domain/exception/UserAlreadyExistsException.java
+++ b/backend/src/main/java/dev/cuong/payment/domain/exception/UserAlreadyExistsException.java
@@ -1,0 +1,8 @@
+package dev.cuong.payment.domain.exception;
+
+public class UserAlreadyExistsException extends DomainException {
+
+    public UserAlreadyExistsException(String field, String value) {
+        super(String.format("User already exists with %s: %s", field, value));
+    }
+}

--- a/backend/src/main/java/dev/cuong/payment/infrastructure/config/SecurityConfig.java
+++ b/backend/src/main/java/dev/cuong/payment/infrastructure/config/SecurityConfig.java
@@ -1,0 +1,43 @@
+package dev.cuong.payment.infrastructure.config;
+
+import dev.cuong.payment.infrastructure.security.JwtAuthenticationFilter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@EnableMethodSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        return http
+                .csrf(AbstractHttpConfigurer::disable)
+                .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/api/auth/**").permitAll()
+                        .requestMatchers("/actuator/health", "/actuator/info").permitAll()
+                        .anyRequest().authenticated()
+                )
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+                .build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/backend/src/main/java/dev/cuong/payment/infrastructure/security/CustomUserDetails.java
+++ b/backend/src/main/java/dev/cuong/payment/infrastructure/security/CustomUserDetails.java
@@ -1,0 +1,44 @@
+package dev.cuong.payment.infrastructure.security;
+
+import dev.cuong.payment.domain.model.User;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Spring Security's view of a user principal, wrapping the domain {@link User}.
+ * Used exclusively by {@link CustomUserDetailsService}; request-scoped authorization
+ * uses the UUID injected directly from the JWT filter into the SecurityContext.
+ */
+@Getter
+public class CustomUserDetails implements UserDetails {
+
+    private final UUID userId;
+    private final String username;
+    private final String password;
+    private final Collection<? extends GrantedAuthority> authorities;
+
+    public CustomUserDetails(User user) {
+        this.userId = user.getId();
+        this.username = user.getUsername();
+        this.password = user.getPasswordHash();
+        this.authorities = List.of(new SimpleGrantedAuthority("ROLE_" + user.getRole().name()));
+    }
+
+    @Override
+    public boolean isAccountNonExpired() { return true; }
+
+    @Override
+    public boolean isAccountNonLocked() { return true; }
+
+    @Override
+    public boolean isCredentialsNonExpired() { return true; }
+
+    @Override
+    public boolean isEnabled() { return true; }
+}

--- a/backend/src/main/java/dev/cuong/payment/infrastructure/security/CustomUserDetailsService.java
+++ b/backend/src/main/java/dev/cuong/payment/infrastructure/security/CustomUserDetailsService.java
@@ -1,0 +1,24 @@
+package dev.cuong.payment.infrastructure.security;
+
+import dev.cuong.payment.application.port.out.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        return userRepository.findByUsername(username)
+                .map(CustomUserDetails::new)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found: " + username));
+    }
+}

--- a/backend/src/main/java/dev/cuong/payment/infrastructure/security/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/dev/cuong/payment/infrastructure/security/JwtAuthenticationFilter.java
@@ -1,0 +1,64 @@
+package dev.cuong.payment.infrastructure.security;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.lang.NonNull;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Extracts the JWT from the Authorization header, validates it, and sets the
+ * authenticated {@link UUID} userId as the principal in the SecurityContext.
+ *
+ * <p>Controllers access the current user via {@code @AuthenticationPrincipal UUID userId}.
+ */
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtService jwtService;
+
+    @Override
+    protected void doFilterInternal(
+            @NonNull HttpServletRequest request,
+            @NonNull HttpServletResponse response,
+            @NonNull FilterChain filterChain) throws ServletException, IOException {
+
+        String authHeader = request.getHeader("Authorization");
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String token = authHeader.substring(7);
+        try {
+            Claims claims = jwtService.validateToken(token);
+            UUID userId = UUID.fromString(claims.getSubject());
+            String role = claims.get("role", String.class);
+
+            UsernamePasswordAuthenticationToken authentication =
+                    new UsernamePasswordAuthenticationToken(
+                            userId,
+                            null,
+                            List.of(new SimpleGrantedAuthority("ROLE_" + role)));
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        } catch (JwtException | IllegalArgumentException e) {
+            // Expired or malformed token — clear context; Spring Security will return 401
+            SecurityContextHolder.clearContext();
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/backend/src/main/java/dev/cuong/payment/infrastructure/security/JwtService.java
+++ b/backend/src/main/java/dev/cuong/payment/infrastructure/security/JwtService.java
@@ -1,0 +1,58 @@
+package dev.cuong.payment.infrastructure.security;
+
+import dev.cuong.payment.domain.vo.UserRole;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import java.util.UUID;
+
+/**
+ * Issues and validates HMAC-SHA256 signed JWTs.
+ *
+ * <p>The secret is injected at construction so this class is directly unit-testable
+ * without a Spring context — pass any 32+ byte key string in tests.
+ */
+@Service
+public class JwtService {
+
+    private final SecretKey signingKey;
+    private final long expirationMs;
+
+    public JwtService(
+            @Value("${app.jwt.secret}") String secret,
+            @Value("${app.jwt.expiration-ms}") long expirationMs) {
+        this.signingKey = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+        this.expirationMs = expirationMs;
+    }
+
+    public String generateToken(UUID userId, String username, UserRole role) {
+        Date now = new Date();
+        return Jwts.builder()
+                .subject(userId.toString())
+                .claim("username", username)
+                .claim("role", role.name())
+                .issuedAt(now)
+                .expiration(new Date(now.getTime() + expirationMs))
+                .signWith(signingKey)
+                .compact();
+    }
+
+    /**
+     * Validates signature and expiry; returns the parsed claims.
+     * Throws {@link JwtException} for any invalid token — callers should catch it.
+     */
+    public Claims validateToken(String token) {
+        return Jwts.parser()
+                .verifyWith(signingKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+    }
+}

--- a/backend/src/main/java/dev/cuong/payment/presentation/auth/AuthController.java
+++ b/backend/src/main/java/dev/cuong/payment/presentation/auth/AuthController.java
@@ -1,0 +1,60 @@
+package dev.cuong.payment.presentation.auth;
+
+import dev.cuong.payment.application.dto.AuthResult;
+import dev.cuong.payment.application.dto.LoginCommand;
+import dev.cuong.payment.application.dto.RegisterUserCommand;
+import dev.cuong.payment.application.port.in.LoginUseCase;
+import dev.cuong.payment.application.port.in.RegisterUserUseCase;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Handles user registration and login.
+ * All endpoints are public (no authentication required).
+ */
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final RegisterUserUseCase registerUserUseCase;
+    private final LoginUseCase loginUseCase;
+
+    /**
+     * Registers a new user and returns a JWT.
+     *
+     * @return 201 with token on success; 409 if username/email taken; 400 on validation error
+     */
+    @PostMapping("/register")
+    public ResponseEntity<AuthResponse> register(@Valid @RequestBody RegisterRequest request) {
+        AuthResult result = registerUserUseCase.register(
+                new RegisterUserCommand(request.username(), request.email(), request.password()));
+        return ResponseEntity.status(HttpStatus.CREATED).body(toResponse(result));
+    }
+
+    /**
+     * Authenticates an existing user and returns a JWT.
+     *
+     * @return 200 with token on success; 401 on bad credentials
+     */
+    @PostMapping("/login")
+    public ResponseEntity<AuthResponse> login(@Valid @RequestBody LoginRequest request) {
+        AuthResult result = loginUseCase.login(
+                new LoginCommand(request.username(), request.password()));
+        return ResponseEntity.ok(toResponse(result));
+    }
+
+    private AuthResponse toResponse(AuthResult result) {
+        return new AuthResponse(
+                result.token(),
+                result.userId().toString(),
+                result.username(),
+                result.role());
+    }
+}

--- a/backend/src/main/java/dev/cuong/payment/presentation/auth/AuthResponse.java
+++ b/backend/src/main/java/dev/cuong/payment/presentation/auth/AuthResponse.java
@@ -1,0 +1,3 @@
+package dev.cuong.payment.presentation.auth;
+
+public record AuthResponse(String token, String userId, String username, String role) {}

--- a/backend/src/main/java/dev/cuong/payment/presentation/auth/LoginRequest.java
+++ b/backend/src/main/java/dev/cuong/payment/presentation/auth/LoginRequest.java
@@ -1,0 +1,8 @@
+package dev.cuong.payment.presentation.auth;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record LoginRequest(
+        @NotBlank(message = "Username is required") String username,
+        @NotBlank(message = "Password is required") String password
+) {}

--- a/backend/src/main/java/dev/cuong/payment/presentation/auth/RegisterRequest.java
+++ b/backend/src/main/java/dev/cuong/payment/presentation/auth/RegisterRequest.java
@@ -1,0 +1,19 @@
+package dev.cuong.payment.presentation.auth;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record RegisterRequest(
+        @NotBlank(message = "Username is required")
+        @Size(min = 3, max = 50, message = "Username must be between 3 and 50 characters")
+        String username,
+
+        @NotBlank(message = "Email is required")
+        @Email(message = "Email must be a valid address")
+        String email,
+
+        @NotBlank(message = "Password is required")
+        @Size(min = 8, message = "Password must be at least 8 characters")
+        String password
+) {}

--- a/backend/src/main/java/dev/cuong/payment/presentation/exception/ApiError.java
+++ b/backend/src/main/java/dev/cuong/payment/presentation/exception/ApiError.java
@@ -1,0 +1,13 @@
+package dev.cuong.payment.presentation.exception;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.time.Instant;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record ApiError(String code, String message, Instant timestamp) {
+
+    public ApiError(String code, String message) {
+        this(code, message, Instant.now());
+    }
+}

--- a/backend/src/main/java/dev/cuong/payment/presentation/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/dev/cuong/payment/presentation/exception/GlobalExceptionHandler.java
@@ -1,0 +1,73 @@
+package dev.cuong.payment.presentation.exception;
+
+import dev.cuong.payment.domain.exception.AccountNotFoundException;
+import dev.cuong.payment.domain.exception.InvalidCredentialsException;
+import dev.cuong.payment.domain.exception.InvalidTransactionStateException;
+import dev.cuong.payment.domain.exception.TransactionNotFoundException;
+import dev.cuong.payment.domain.exception.UserAlreadyExistsException;
+import dev.cuong.payment.domain.exception.UserNotFoundException;
+import dev.cuong.payment.domain.exception.InsufficientFundsException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.stream.Collectors;
+
+/**
+ * Maps domain exceptions to HTTP status codes in one place.
+ * Controllers throw; this class decides the status code and response shape.
+ */
+@RestControllerAdvice
+@Slf4j
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(UserAlreadyExistsException.class)
+    public ResponseEntity<ApiError> handleUserAlreadyExists(UserAlreadyExistsException e) {
+        return ResponseEntity.status(HttpStatus.CONFLICT)
+                .body(new ApiError("USER_ALREADY_EXISTS", e.getMessage()));
+    }
+
+    @ExceptionHandler(InvalidCredentialsException.class)
+    public ResponseEntity<ApiError> handleInvalidCredentials(InvalidCredentialsException e) {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                .body(new ApiError("INVALID_CREDENTIALS", e.getMessage()));
+    }
+
+    @ExceptionHandler({TransactionNotFoundException.class, AccountNotFoundException.class, UserNotFoundException.class})
+    public ResponseEntity<ApiError> handleNotFound(Exception e) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(new ApiError("NOT_FOUND", e.getMessage()));
+    }
+
+    @ExceptionHandler(InsufficientFundsException.class)
+    public ResponseEntity<ApiError> handleInsufficientFunds(InsufficientFundsException e) {
+        return ResponseEntity.status(HttpStatus.UNPROCESSABLE_ENTITY)
+                .body(new ApiError("INSUFFICIENT_FUNDS", e.getMessage()));
+    }
+
+    @ExceptionHandler(InvalidTransactionStateException.class)
+    public ResponseEntity<ApiError> handleInvalidState(InvalidTransactionStateException e) {
+        return ResponseEntity.status(HttpStatus.CONFLICT)
+                .body(new ApiError("INVALID_TRANSACTION_STATE", e.getMessage()));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiError> handleValidation(MethodArgumentNotValidException e) {
+        String message = e.getBindingResult().getFieldErrors().stream()
+                .map(FieldError::getDefaultMessage)
+                .collect(Collectors.joining("; "));
+        return ResponseEntity.badRequest()
+                .body(new ApiError("VALIDATION_ERROR", message));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiError> handleUnexpected(Exception e) {
+        log.error("Unhandled exception: {}", e.getMessage(), e);
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(new ApiError("INTERNAL_ERROR", "An unexpected error occurred"));
+    }
+}

--- a/backend/src/test/java/dev/cuong/payment/infrastructure/security/JwtServiceTest.java
+++ b/backend/src/test/java/dev/cuong/payment/infrastructure/security/JwtServiceTest.java
@@ -1,0 +1,82 @@
+package dev.cuong.payment.infrastructure.security;
+
+import dev.cuong.payment.domain.vo.UserRole;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class JwtServiceTest {
+
+    // 33 chars × 8 bits = 264 bits — meets HS256 minimum of 256 bits
+    private static final String TEST_SECRET = "test-secret-key-minimum-32-chars!";
+    private static final long EXPIRATION_MS = 3_600_000L; // 1 hour
+
+    private JwtService jwtService;
+    private UUID userId;
+
+    @BeforeEach
+    void setUp() {
+        jwtService = new JwtService(TEST_SECRET, EXPIRATION_MS);
+        userId = UUID.randomUUID();
+    }
+
+    @Test
+    void should_generate_parseable_token() {
+        String token = jwtService.generateToken(userId, "alice", UserRole.USER);
+
+        assertThat(token).isNotBlank();
+        assertThat(token.split("\\.")).hasSize(3); // header.payload.signature
+    }
+
+    @Test
+    void should_embed_user_id_as_subject() {
+        String token = jwtService.generateToken(userId, "alice", UserRole.USER);
+
+        Claims claims = jwtService.validateToken(token);
+
+        assertThat(claims.getSubject()).isEqualTo(userId.toString());
+    }
+
+    @Test
+    void should_embed_username_and_role_claims() {
+        String token = jwtService.generateToken(userId, "alice", UserRole.ADMIN);
+
+        Claims claims = jwtService.validateToken(token);
+
+        assertThat(claims.get("username", String.class)).isEqualTo("alice");
+        assertThat(claims.get("role", String.class)).isEqualTo("ADMIN");
+    }
+
+    @Test
+    void should_reject_tampered_token() {
+        String token = jwtService.generateToken(userId, "alice", UserRole.USER);
+        String tampered = token.substring(0, token.length() - 4) + "XXXX";
+
+        assertThatThrownBy(() -> jwtService.validateToken(tampered))
+                .isInstanceOf(JwtException.class);
+    }
+
+    @Test
+    void should_reject_token_signed_with_different_secret() {
+        JwtService otherService = new JwtService("another-secret-key-minimum-32-chars!", EXPIRATION_MS);
+        String foreignToken = otherService.generateToken(userId, "alice", UserRole.USER);
+
+        assertThatThrownBy(() -> jwtService.validateToken(foreignToken))
+                .isInstanceOf(JwtException.class);
+    }
+
+    @Test
+    void should_reject_expired_token() {
+        JwtService shortLivedService = new JwtService(TEST_SECRET, -1L); // already expired
+        String expiredToken = shortLivedService.generateToken(userId, "alice", UserRole.USER);
+
+        assertThatThrownBy(() -> jwtService.validateToken(expiredToken))
+                .isInstanceOf(JwtException.class);
+    }
+}

--- a/backend/src/test/java/dev/cuong/payment/presentation/auth/AuthIntegrationTest.java
+++ b/backend/src/test/java/dev/cuong/payment/presentation/auth/AuthIntegrationTest.java
@@ -1,0 +1,176 @@
+package dev.cuong.payment.presentation.auth;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.transaction.annotation.Transactional;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Testcontainers
+@Transactional
+@TestPropertySource(properties = {
+        "spring.autoconfigure.exclude=" +
+                "org.redisson.spring.starter.RedissonAutoConfigurationV2," +
+                "org.springframework.boot.autoconfigure.kafka.KafkaAutoConfiguration",
+        "spring.flyway.enabled=true",
+        "app.jwt.secret=test-secret-key-minimum-32-chars-for-hs256!"
+})
+class AuthIntegrationTest {
+
+    @Container
+    @ServiceConnection
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:15-alpine");
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    // ── Register ─────────────────────────────────────────────────────────────
+
+    @Test
+    void should_register_user_and_return_token() throws Exception {
+        mockMvc.perform(post("/api/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(registerBody("alice", "alice@test.com", "password123")))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.token").isNotEmpty())
+                .andExpect(jsonPath("$.username").value("alice"))
+                .andExpect(jsonPath("$.role").value("USER"));
+    }
+
+    @Test
+    void should_reject_duplicate_username_with_409() throws Exception {
+        mockMvc.perform(post("/api/auth/register")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(registerBody("bob", "bob1@test.com", "password123")));
+
+        mockMvc.perform(post("/api/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(registerBody("bob", "bob2@test.com", "password123")))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("USER_ALREADY_EXISTS"));
+    }
+
+    @Test
+    void should_reject_duplicate_email_with_409() throws Exception {
+        mockMvc.perform(post("/api/auth/register")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(registerBody("carol1", "shared@test.com", "password123")));
+
+        mockMvc.perform(post("/api/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(registerBody("carol2", "shared@test.com", "password123")))
+                .andExpect(status().isConflict());
+    }
+
+    @Test
+    void should_reject_short_password_with_400() throws Exception {
+        mockMvc.perform(post("/api/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(registerBody("dave", "dave@test.com", "short")))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"));
+    }
+
+    @Test
+    void should_reject_invalid_email_with_400() throws Exception {
+        mockMvc.perform(post("/api/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(registerBody("eve", "not-an-email", "password123")))
+                .andExpect(status().isBadRequest());
+    }
+
+    // ── Login ─────────────────────────────────────────────────────────────────
+
+    @Test
+    void should_login_and_return_token_after_registration() throws Exception {
+        mockMvc.perform(post("/api/auth/register")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(registerBody("frank", "frank@test.com", "password123")));
+
+        mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(loginBody("frank", "password123")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.token").isNotEmpty())
+                .andExpect(jsonPath("$.username").value("frank"));
+    }
+
+    @Test
+    void should_reject_wrong_password_with_401() throws Exception {
+        mockMvc.perform(post("/api/auth/register")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(registerBody("grace", "grace@test.com", "password123")));
+
+        mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(loginBody("grace", "wrongpassword")))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("INVALID_CREDENTIALS"));
+    }
+
+    @Test
+    void should_reject_nonexistent_user_with_401() throws Exception {
+        mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(loginBody("nobody", "password123")))
+                .andExpect(status().isUnauthorized());
+    }
+
+    // ── JWT on protected routes ───────────────────────────────────────────────
+
+    @Test
+    void should_reject_unauthenticated_request_to_protected_route() throws Exception {
+        mockMvc.perform(get("/api/transactions"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void should_allow_authenticated_request_with_valid_token() throws Exception {
+        MvcResult registerResult = mockMvc.perform(post("/api/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(registerBody("henry", "henry@test.com", "password123")))
+                .andReturn();
+
+        String token = objectMapper
+                .readTree(registerResult.getResponse().getContentAsString())
+                .get("token").asText();
+
+        // /api/transactions doesn't exist yet but Spring Security should return 404 (not 401)
+        // meaning the JWT was accepted and the request passed the security filter
+        mockMvc.perform(get("/api/transactions")
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(result ->
+                        assertThat(result.getResponse().getStatus()).isNotEqualTo(401));
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private String registerBody(String username, String email, String password) throws Exception {
+        return objectMapper.writeValueAsString(
+                new RegisterRequest(username, email, password));
+    }
+
+    private String loginBody(String username, String password) throws Exception {
+        return objectMapper.writeValueAsString(new LoginRequest(username, password));
+    }
+}


### PR DESCRIPTION
## What this PR does
Closes #7 

Adds stateless JWT authentication end-to-end: from POST /api/auth/register and
POST /api/auth/login that issue tokens, through the JwtAuthenticationFilter that
validates tokens on every request, to the SecurityConfig that locks all routes
except /api/auth/** and /actuator/health. Introduces GlobalExceptionHandler which
maps every DomainException to an appropriate HTTP status - this is the single
centralized error-response mapping for the whole service.

## How to test
1. Start Docker Desktop and run: docker-compose up -d
2. ./gradlew test   (runs all tests including AuthIntegrationTest)
3. Manual smoke test:
   curl -X POST localhost:8080/api/auth/register \
     -H 'Content-Type: application/json' \
     -d '{"username":"alice","email":"alice@example.com","password":"password123"}'
   → 201 with token
   curl localhost:8080/api/transactions   → 401 (no token)
   curl localhost:8080/api/transactions -H 'Authorization: Bearer <token>'  → 404 (endpoint not built yet, but not 401)

## Technical decisions
- @AuthenticationPrincipal UUID userId in controllers instead of UserDetails:
  the filter sets the UUID directly as the Authentication principal. Controllers
  never see a UserDetails object - they just get the UUID they need for business logic.
- Same exception for wrong password and unknown user: prevents username enumeration
  attacks where a different error code for "user not found" vs "wrong password"
  reveals which usernames are registered.
- GlobalExceptionHandler in presentation layer, not a filter: Spring's @ControllerAdvice
  integrates cleanly with MockMvc in tests and gives full access to the exception's
  fields for building structured error responses.