### PR TITLE
Task/06-account-management

### DIFF
--- a/backend/src/main/java/dev/cuong/payment/application/dto/AccountResult.java
+++ b/backend/src/main/java/dev/cuong/payment/application/dto/AccountResult.java
@@ -1,0 +1,13 @@
+package dev.cuong.payment.application.dto;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+
+public record AccountResult(
+        UUID id,
+        UUID userId,
+        BigDecimal balance,
+        String currency,
+        Instant createdAt
+) {}

--- a/backend/src/main/java/dev/cuong/payment/application/dto/UserProfileResult.java
+++ b/backend/src/main/java/dev/cuong/payment/application/dto/UserProfileResult.java
@@ -1,0 +1,12 @@
+package dev.cuong.payment.application.dto;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record UserProfileResult(
+        UUID id,
+        String username,
+        String email,
+        String role,
+        Instant createdAt
+) {}

--- a/backend/src/main/java/dev/cuong/payment/application/port/in/GetAccountUseCase.java
+++ b/backend/src/main/java/dev/cuong/payment/application/port/in/GetAccountUseCase.java
@@ -1,0 +1,13 @@
+package dev.cuong.payment.application.port.in;
+
+import dev.cuong.payment.application.dto.AccountResult;
+
+import java.util.UUID;
+
+/**
+ * Input port: retrieve the authenticated user's account balance and details.
+ */
+public interface GetAccountUseCase {
+
+    AccountResult getAccount(UUID userId);
+}

--- a/backend/src/main/java/dev/cuong/payment/application/port/in/GetUserProfileUseCase.java
+++ b/backend/src/main/java/dev/cuong/payment/application/port/in/GetUserProfileUseCase.java
@@ -1,0 +1,13 @@
+package dev.cuong.payment.application.port.in;
+
+import dev.cuong.payment.application.dto.UserProfileResult;
+
+import java.util.UUID;
+
+/**
+ * Input port: retrieve the authenticated user's profile.
+ */
+public interface GetUserProfileUseCase {
+
+    UserProfileResult getProfile(UUID userId);
+}

--- a/backend/src/main/java/dev/cuong/payment/application/service/AccountApplicationService.java
+++ b/backend/src/main/java/dev/cuong/payment/application/service/AccountApplicationService.java
@@ -1,0 +1,36 @@
+package dev.cuong.payment.application.service;
+
+import dev.cuong.payment.application.dto.AccountResult;
+import dev.cuong.payment.application.port.in.GetAccountUseCase;
+import dev.cuong.payment.application.port.out.AccountRepository;
+import dev.cuong.payment.domain.exception.AccountNotFoundException;
+import dev.cuong.payment.domain.model.Account;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AccountApplicationService implements GetAccountUseCase {
+
+    private final AccountRepository accountRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public AccountResult getAccount(UUID userId) {
+        Account account = accountRepository.findByUserId(userId)
+                .orElseThrow(() -> new AccountNotFoundException(userId));
+
+        log.info("Account retrieved: userId={}, accountId={}", userId, account.getId());
+        return new AccountResult(
+                account.getId(),
+                account.getUserId(),
+                account.getBalance(),
+                account.getCurrency(),
+                account.getCreatedAt());
+    }
+}

--- a/backend/src/main/java/dev/cuong/payment/application/service/AuthApplicationService.java
+++ b/backend/src/main/java/dev/cuong/payment/application/service/AuthApplicationService.java
@@ -5,9 +5,11 @@ import dev.cuong.payment.application.dto.LoginCommand;
 import dev.cuong.payment.application.dto.RegisterUserCommand;
 import dev.cuong.payment.application.port.in.LoginUseCase;
 import dev.cuong.payment.application.port.in.RegisterUserUseCase;
+import dev.cuong.payment.application.port.out.AccountRepository;
 import dev.cuong.payment.application.port.out.UserRepository;
 import dev.cuong.payment.domain.exception.InvalidCredentialsException;
 import dev.cuong.payment.domain.exception.UserAlreadyExistsException;
+import dev.cuong.payment.domain.model.Account;
 import dev.cuong.payment.domain.model.User;
 import dev.cuong.payment.domain.vo.UserRole;
 import dev.cuong.payment.infrastructure.security.JwtService;
@@ -17,6 +19,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.math.BigDecimal;
 import java.time.Instant;
 
 @Service
@@ -25,6 +28,7 @@ import java.time.Instant;
 public class AuthApplicationService implements RegisterUserUseCase, LoginUseCase {
 
     private final UserRepository userRepository;
+    private final AccountRepository accountRepository;
     private final PasswordEncoder passwordEncoder;
     private final JwtService jwtService;
 
@@ -49,6 +53,18 @@ public class AuthApplicationService implements RegisterUserUseCase, LoginUseCase
                 .build();
 
         User saved = userRepository.save(user);
+
+        // Account created atomically with the user — same @Transactional boundary.
+        // If account INSERT fails, the user row rolls back too (no orphaned users).
+        Account account = Account.builder()
+                .userId(saved.getId())
+                .balance(BigDecimal.ZERO)
+                .currency("USD")
+                .createdAt(now)
+                .updatedAt(now)
+                .build();
+        accountRepository.save(account);
+
         String token = jwtService.generateToken(saved.getId(), saved.getUsername(), saved.getRole());
 
         log.info("User registered: userId={}, username={}", saved.getId(), saved.getUsername());

--- a/backend/src/main/java/dev/cuong/payment/application/service/UserApplicationService.java
+++ b/backend/src/main/java/dev/cuong/payment/application/service/UserApplicationService.java
@@ -1,0 +1,36 @@
+package dev.cuong.payment.application.service;
+
+import dev.cuong.payment.application.dto.UserProfileResult;
+import dev.cuong.payment.application.port.in.GetUserProfileUseCase;
+import dev.cuong.payment.application.port.out.UserRepository;
+import dev.cuong.payment.domain.exception.UserNotFoundException;
+import dev.cuong.payment.domain.model.User;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class UserApplicationService implements GetUserProfileUseCase {
+
+    private final UserRepository userRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public UserProfileResult getProfile(UUID userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserNotFoundException(userId));
+
+        log.info("Profile retrieved: userId={}", userId);
+        return new UserProfileResult(
+                user.getId(),
+                user.getUsername(),
+                user.getEmail(),
+                user.getRole().name(),
+                user.getCreatedAt());
+    }
+}

--- a/backend/src/main/java/dev/cuong/payment/presentation/account/AccountController.java
+++ b/backend/src/main/java/dev/cuong/payment/presentation/account/AccountController.java
@@ -1,0 +1,39 @@
+package dev.cuong.payment.presentation.account;
+
+import dev.cuong.payment.application.dto.AccountResult;
+import dev.cuong.payment.application.port.in.GetAccountUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+/**
+ * Exposes account balance and metadata for the authenticated user.
+ */
+@RestController
+@RequestMapping("/api/accounts")
+@RequiredArgsConstructor
+public class AccountController {
+
+    private final GetAccountUseCase getAccountUseCase;
+
+    /**
+     * Returns the authenticated user's account details and current balance.
+     *
+     * @return 200 with account; 401 if unauthenticated; 404 if account record missing
+     */
+    @GetMapping("/me")
+    public ResponseEntity<AccountResponse> getMe(@AuthenticationPrincipal UUID userId) {
+        AccountResult result = getAccountUseCase.getAccount(userId);
+        return ResponseEntity.ok(new AccountResponse(
+                result.id().toString(),
+                result.userId().toString(),
+                result.balance(),
+                result.currency(),
+                result.createdAt().toString()));
+    }
+}

--- a/backend/src/main/java/dev/cuong/payment/presentation/account/AccountResponse.java
+++ b/backend/src/main/java/dev/cuong/payment/presentation/account/AccountResponse.java
@@ -1,0 +1,11 @@
+package dev.cuong.payment.presentation.account;
+
+import java.math.BigDecimal;
+
+public record AccountResponse(
+        String id,
+        String userId,
+        BigDecimal balance,
+        String currency,
+        String createdAt
+) {}

--- a/backend/src/main/java/dev/cuong/payment/presentation/user/UserController.java
+++ b/backend/src/main/java/dev/cuong/payment/presentation/user/UserController.java
@@ -1,0 +1,39 @@
+package dev.cuong.payment.presentation.user;
+
+import dev.cuong.payment.application.dto.UserProfileResult;
+import dev.cuong.payment.application.port.in.GetUserProfileUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+/**
+ * Exposes read-only user profile data for the authenticated user.
+ */
+@RestController
+@RequestMapping("/api/users")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final GetUserProfileUseCase getUserProfileUseCase;
+
+    /**
+     * Returns the authenticated user's profile.
+     *
+     * @return 200 with profile; 401 if unauthenticated; 404 if user record missing
+     */
+    @GetMapping("/me")
+    public ResponseEntity<UserProfileResponse> getMe(@AuthenticationPrincipal UUID userId) {
+        UserProfileResult result = getUserProfileUseCase.getProfile(userId);
+        return ResponseEntity.ok(new UserProfileResponse(
+                result.id().toString(),
+                result.username(),
+                result.email(),
+                result.role(),
+                result.createdAt().toString()));
+    }
+}

--- a/backend/src/main/java/dev/cuong/payment/presentation/user/UserProfileResponse.java
+++ b/backend/src/main/java/dev/cuong/payment/presentation/user/UserProfileResponse.java
@@ -1,0 +1,9 @@
+package dev.cuong.payment.presentation.user;
+
+public record UserProfileResponse(
+        String id,
+        String username,
+        String email,
+        String role,
+        String createdAt
+) {}

--- a/backend/src/test/java/dev/cuong/payment/presentation/UserAccountIntegrationTest.java
+++ b/backend/src/test/java/dev/cuong/payment/presentation/UserAccountIntegrationTest.java
@@ -1,0 +1,150 @@
+package dev.cuong.payment.presentation;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.cuong.payment.presentation.auth.RegisterRequest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.transaction.annotation.Transactional;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Testcontainers
+@Transactional
+@TestPropertySource(properties = {
+        "spring.autoconfigure.exclude=" +
+                "org.redisson.spring.starter.RedissonAutoConfigurationV2," +
+                "org.springframework.boot.autoconfigure.kafka.KafkaAutoConfiguration",
+        "spring.flyway.enabled=true",
+        "app.jwt.secret=test-secret-key-minimum-32-chars-for-hs256!"
+})
+class UserAccountIntegrationTest {
+
+    @Container
+    @ServiceConnection
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:15-alpine");
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    // ── GET /api/users/me ────────────────────────────────────────────────────
+
+    @Test
+    void should_return_profile_when_authenticated() throws Exception {
+        String token = registerAndGetToken("alice", "alice@test.com", "password123");
+
+        mockMvc.perform(get("/api/users/me")
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.username").value("alice"))
+                .andExpect(jsonPath("$.email").value("alice@test.com"))
+                .andExpect(jsonPath("$.role").value("USER"))
+                .andExpect(jsonPath("$.id").isNotEmpty())
+                .andExpect(jsonPath("$.createdAt").isNotEmpty());
+    }
+
+    @Test
+    void should_reject_profile_request_when_unauthenticated() throws Exception {
+        mockMvc.perform(get("/api/users/me"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void should_reject_profile_request_when_token_is_invalid() throws Exception {
+        mockMvc.perform(get("/api/users/me")
+                        .header("Authorization", "Bearer not.a.real.token"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    // ── GET /api/accounts/me ─────────────────────────────────────────────────
+
+    @Test
+    void should_return_account_with_zero_balance_after_registration() throws Exception {
+        String token = registerAndGetToken("bob", "bob@test.com", "password123");
+
+        mockMvc.perform(get("/api/accounts/me")
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.balance").value(0))
+                .andExpect(jsonPath("$.currency").value("USD"))
+                .andExpect(jsonPath("$.id").isNotEmpty())
+                .andExpect(jsonPath("$.userId").isNotEmpty());
+    }
+
+    @Test
+    void should_reject_account_request_when_unauthenticated() throws Exception {
+        mockMvc.perform(get("/api/accounts/me"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void should_return_matching_user_id_in_profile_and_account() throws Exception {
+        String token = registerAndGetToken("carol", "carol@test.com", "password123");
+
+        MvcResult profileResult = mockMvc.perform(get("/api/users/me")
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        MvcResult accountResult = mockMvc.perform(get("/api/accounts/me")
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        String profileId = objectMapper
+                .readTree(profileResult.getResponse().getContentAsString())
+                .get("id").asText();
+        String accountUserId = objectMapper
+                .readTree(accountResult.getResponse().getContentAsString())
+                .get("userId").asText();
+
+        assertThat(profileId).isEqualTo(accountUserId);
+    }
+
+    @Test
+    void should_scope_profile_to_the_authenticated_user() throws Exception {
+        String tokenDave = registerAndGetToken("dave", "dave@test.com", "password123");
+        String tokenEve  = registerAndGetToken("eve",  "eve@test.com",  "password123");
+
+        mockMvc.perform(get("/api/users/me").header("Authorization", "Bearer " + tokenDave))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.username").value("dave"));
+
+        mockMvc.perform(get("/api/users/me").header("Authorization", "Bearer " + tokenEve))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.username").value("eve"));
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private String registerAndGetToken(String username, String email, String password) throws Exception {
+        MvcResult result = mockMvc.perform(post("/api/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                new RegisterRequest(username, email, password))))
+                .andExpect(status().isCreated())
+                .andReturn();
+
+        return objectMapper
+                .readTree(result.getResponse().getContentAsString())
+                .get("token").asText();
+    }
+}


### PR DESCRIPTION
## What this PR does
Closes #8 

Completes the user onboarding flow. Registration now atomically creates a
zero-balance USD Account alongside the User in the same @Transactional
boundary. Two read endpoints, protected by JWT, expose profile and balance
data to authenticated clients.

## How to test
1. POST /api/auth/register → save the returned token
2. GET /api/users/me  Authorization: Bearer <token> → 200 {id, username, email, role, createdAt}
3. GET /api/accounts/me  Authorization: Bearer <token> → 200 {id, userId, balance:0, currency:"USD"}
4. GET /api/users/me without token → 401
5. Run UserAccountIntegrationTest (requires Docker)

## Technical decisions
- Account creation lives inside AuthApplicationService.register(), not a
  separate use case, to share the @Transactional boundary and guarantee atomicity.
- Currency is hardcoded to "USD" - multi-currency is a future concern (YAGNI).
- Response fields id/userId/createdAt are serialized as String (toString of UUID/Instant)
  to give clients predictable, unambiguous types without requiring custom serializers.