### PR TITLE
Task/07-transaction-creation

### DIFF
--- a/backend/src/main/java/dev/cuong/payment/application/dto/CreateTransactionCommand.java
+++ b/backend/src/main/java/dev/cuong/payment/application/dto/CreateTransactionCommand.java
@@ -1,0 +1,14 @@
+package dev.cuong.payment.application.dto;
+
+import dev.cuong.payment.domain.vo.TransactionType;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+public record CreateTransactionCommand(
+        UUID userId,
+        BigDecimal amount,
+        TransactionType type,
+        String description,
+        String idempotencyKey
+) {}

--- a/backend/src/main/java/dev/cuong/payment/application/dto/TransactionResult.java
+++ b/backend/src/main/java/dev/cuong/payment/application/dto/TransactionResult.java
@@ -1,0 +1,23 @@
+package dev.cuong.payment.application.dto;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+
+public record TransactionResult(
+        UUID id,
+        UUID userId,
+        UUID accountId,
+        BigDecimal amount,
+        String currency,
+        String type,
+        String status,
+        String description,
+        String idempotencyKey,
+        String gatewayReference,
+        String failureReason,
+        Instant processedAt,
+        Instant refundedAt,
+        Instant createdAt,
+        Instant updatedAt
+) {}

--- a/backend/src/main/java/dev/cuong/payment/application/port/in/CreateTransactionUseCase.java
+++ b/backend/src/main/java/dev/cuong/payment/application/port/in/CreateTransactionUseCase.java
@@ -1,0 +1,16 @@
+package dev.cuong.payment.application.port.in;
+
+import dev.cuong.payment.application.dto.CreateTransactionCommand;
+import dev.cuong.payment.application.dto.TransactionResult;
+
+/**
+ * Input port: create a new payment transaction with idempotency guarantee.
+ *
+ * <p>Callers must provide a unique {@code idempotencyKey} per logical operation.
+ * Submitting the same key a second time returns the cached result without
+ * re-executing the business logic.
+ */
+public interface CreateTransactionUseCase {
+
+    TransactionResult createTransaction(CreateTransactionCommand command);
+}

--- a/backend/src/main/java/dev/cuong/payment/application/service/TransactionApplicationService.java
+++ b/backend/src/main/java/dev/cuong/payment/application/service/TransactionApplicationService.java
@@ -1,0 +1,93 @@
+package dev.cuong.payment.application.service;
+
+import dev.cuong.payment.application.dto.CreateTransactionCommand;
+import dev.cuong.payment.application.dto.TransactionResult;
+import dev.cuong.payment.application.port.in.CreateTransactionUseCase;
+import dev.cuong.payment.application.port.out.AccountRepository;
+import dev.cuong.payment.application.port.out.TransactionRepository;
+import dev.cuong.payment.domain.exception.AccountNotFoundException;
+import dev.cuong.payment.domain.model.Account;
+import dev.cuong.payment.domain.model.Transaction;
+import dev.cuong.payment.domain.vo.TransactionStatus;
+import dev.cuong.payment.domain.vo.TransactionType;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class TransactionApplicationService implements CreateTransactionUseCase {
+
+    private final TransactionRepository transactionRepository;
+    private final AccountRepository accountRepository;
+
+    @Override
+    @Transactional
+    public TransactionResult createTransaction(CreateTransactionCommand command) {
+        // Idempotency: return cached result if this key was already processed
+        Optional<Transaction> existing =
+                transactionRepository.findByIdempotencyKey(command.idempotencyKey());
+        if (existing.isPresent()) {
+            log.info("Idempotent replay: key={}, transactionId={}",
+                    command.idempotencyKey(), existing.get().getId());
+            return toResult(existing.get());
+        }
+
+        // Pessimistic lock: prevents concurrent balance updates for the same account
+        Account account = accountRepository.findByUserIdForUpdate(command.userId())
+                .orElseThrow(() -> new AccountNotFoundException(command.userId()));
+
+        // DEPOSIT credits the account; all other types debit (throws if insufficient funds)
+        if (command.type() == TransactionType.DEPOSIT) {
+            account.credit(command.amount());
+        } else {
+            account.debit(command.amount());
+        }
+
+        Instant now = Instant.now();
+        Transaction transaction = Transaction.builder()
+                .userId(command.userId())
+                .accountId(account.getId())
+                .amount(command.amount())
+                .currency(account.getCurrency())
+                .type(command.type())
+                .status(TransactionStatus.PENDING)
+                .description(command.description())
+                .idempotencyKey(command.idempotencyKey())
+                .createdAt(now)
+                .updatedAt(now)
+                .build();
+
+        accountRepository.save(account);
+        Transaction saved = transactionRepository.save(transaction);
+
+        log.info("Transaction created: transactionId={}, userId={}, amount={}, type={}, status={}",
+                saved.getId(), command.userId(), command.amount(), command.type(), saved.getStatus());
+
+        return toResult(saved);
+    }
+
+    private TransactionResult toResult(Transaction tx) {
+        return new TransactionResult(
+                tx.getId(),
+                tx.getUserId(),
+                tx.getAccountId(),
+                tx.getAmount(),
+                tx.getCurrency(),
+                tx.getType().name(),
+                tx.getStatus().name(),
+                tx.getDescription(),
+                tx.getIdempotencyKey(),
+                tx.getGatewayReference(),
+                tx.getFailureReason(),
+                tx.getProcessedAt(),
+                tx.getRefundedAt(),
+                tx.getCreatedAt(),
+                tx.getUpdatedAt());
+    }
+}

--- a/backend/src/main/java/dev/cuong/payment/presentation/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/dev/cuong/payment/presentation/exception/GlobalExceptionHandler.java
@@ -12,6 +12,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingRequestHeaderException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -53,6 +54,12 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ApiError> handleInvalidState(InvalidTransactionStateException e) {
         return ResponseEntity.status(HttpStatus.CONFLICT)
                 .body(new ApiError("INVALID_TRANSACTION_STATE", e.getMessage()));
+    }
+
+    @ExceptionHandler(MissingRequestHeaderException.class)
+    public ResponseEntity<ApiError> handleMissingHeader(MissingRequestHeaderException e) {
+        return ResponseEntity.badRequest()
+                .body(new ApiError("MISSING_HEADER", e.getMessage()));
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)

--- a/backend/src/main/java/dev/cuong/payment/presentation/transaction/CreateTransactionRequest.java
+++ b/backend/src/main/java/dev/cuong/payment/presentation/transaction/CreateTransactionRequest.java
@@ -1,0 +1,20 @@
+package dev.cuong.payment.presentation.transaction;
+
+import dev.cuong.payment.domain.vo.TransactionType;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
+
+import java.math.BigDecimal;
+
+public record CreateTransactionRequest(
+        @NotNull(message = "amount is required")
+        @Positive(message = "amount must be positive")
+        BigDecimal amount,
+
+        @NotNull(message = "type is required")
+        TransactionType type,
+
+        @Size(max = 500, message = "description must not exceed 500 characters")
+        String description
+) {}

--- a/backend/src/main/java/dev/cuong/payment/presentation/transaction/TransactionController.java
+++ b/backend/src/main/java/dev/cuong/payment/presentation/transaction/TransactionController.java
@@ -1,0 +1,73 @@
+package dev.cuong.payment.presentation.transaction;
+
+import dev.cuong.payment.application.dto.CreateTransactionCommand;
+import dev.cuong.payment.application.dto.TransactionResult;
+import dev.cuong.payment.application.port.in.CreateTransactionUseCase;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+/**
+ * Handles transaction lifecycle operations.
+ * All endpoints require a valid JWT. Write operations require {@code Idempotency-Key}.
+ */
+@RestController
+@RequestMapping("/api/transactions")
+@RequiredArgsConstructor
+public class TransactionController {
+
+    private final CreateTransactionUseCase createTransactionUseCase;
+
+    /**
+     * Creates a new transaction and updates the account balance atomically.
+     *
+     * <p>The {@code Idempotency-Key} header is required. Submitting the same key
+     * twice returns the original 201 response without re-executing the operation.
+     *
+     * @return 201 with transaction details; 400 on missing header or validation error;
+     *         401 if unauthenticated; 422 if balance is insufficient
+     */
+    @PostMapping
+    public ResponseEntity<TransactionResponse> createTransaction(
+            @AuthenticationPrincipal UUID userId,
+            @RequestHeader("Idempotency-Key") String idempotencyKey,
+            @Valid @RequestBody CreateTransactionRequest request) {
+
+        TransactionResult result = createTransactionUseCase.createTransaction(
+                new CreateTransactionCommand(
+                        userId,
+                        request.amount(),
+                        request.type(),
+                        request.description(),
+                        idempotencyKey));
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(toResponse(result));
+    }
+
+    private TransactionResponse toResponse(TransactionResult r) {
+        return new TransactionResponse(
+                r.id().toString(),
+                r.userId().toString(),
+                r.accountId().toString(),
+                r.amount(),
+                r.currency(),
+                r.type(),
+                r.status(),
+                r.description(),
+                r.gatewayReference(),
+                r.failureReason(),
+                r.processedAt() != null ? r.processedAt().toString() : null,
+                r.refundedAt() != null ? r.refundedAt().toString() : null,
+                r.createdAt().toString(),
+                r.updatedAt().toString());
+    }
+}

--- a/backend/src/main/java/dev/cuong/payment/presentation/transaction/TransactionResponse.java
+++ b/backend/src/main/java/dev/cuong/payment/presentation/transaction/TransactionResponse.java
@@ -1,0 +1,20 @@
+package dev.cuong.payment.presentation.transaction;
+
+import java.math.BigDecimal;
+
+public record TransactionResponse(
+        String id,
+        String userId,
+        String accountId,
+        BigDecimal amount,
+        String currency,
+        String type,
+        String status,
+        String description,
+        String gatewayReference,
+        String failureReason,
+        String processedAt,
+        String refundedAt,
+        String createdAt,
+        String updatedAt
+) {}

--- a/backend/src/test/java/dev/cuong/payment/presentation/transaction/TransactionCreationIntegrationTest.java
+++ b/backend/src/test/java/dev/cuong/payment/presentation/transaction/TransactionCreationIntegrationTest.java
@@ -1,0 +1,234 @@
+package dev.cuong.payment.presentation.transaction;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.cuong.payment.application.port.out.AccountRepository;
+import dev.cuong.payment.domain.model.Account;
+import dev.cuong.payment.presentation.auth.RegisterRequest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.transaction.annotation.Transactional;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Testcontainers
+@Transactional
+@TestPropertySource(properties = {
+        "spring.autoconfigure.exclude=" +
+                "org.redisson.spring.starter.RedissonAutoConfigurationV2," +
+                "org.springframework.boot.autoconfigure.kafka.KafkaAutoConfiguration",
+        "spring.flyway.enabled=true",
+        "app.jwt.secret=test-secret-key-minimum-32-chars-for-hs256!"
+})
+class TransactionCreationIntegrationTest {
+
+    @Container
+    @ServiceConnection
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:15-alpine");
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private AccountRepository accountRepository;
+
+    // ── DEPOSIT ──────────────────────────────────────────────────────────────
+
+    @Test
+    void should_create_deposit_and_credit_account() throws Exception {
+        String token = registerAndGetToken("alice", "alice@test.com", "password123");
+
+        mockMvc.perform(post("/api/transactions")
+                        .header("Authorization", "Bearer " + token)
+                        .header("Idempotency-Key", UUID.randomUUID().toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(transactionBody("500.00", "DEPOSIT", "Initial deposit")))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.status").value("PENDING"))
+                .andExpect(jsonPath("$.type").value("DEPOSIT"))
+                .andExpect(jsonPath("$.amount").value(500.00))
+                .andExpect(jsonPath("$.currency").value("USD"))
+                .andExpect(jsonPath("$.id").isNotEmpty());
+    }
+
+    // ── PAYMENT ───────────────────────────────────────────────────────────────
+
+    @Test
+    void should_create_payment_and_debit_account_when_funds_are_sufficient() throws Exception {
+        String token = registerAndGetToken("bob", "bob@test.com", "password123");
+        UUID userId = extractUserId(token);
+        fundAccount(userId, new BigDecimal("1000.00"));
+
+        mockMvc.perform(post("/api/transactions")
+                        .header("Authorization", "Bearer " + token)
+                        .header("Idempotency-Key", UUID.randomUUID().toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(transactionBody("250.00", "PAYMENT", "Netflix subscription")))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.status").value("PENDING"))
+                .andExpect(jsonPath("$.type").value("PAYMENT"))
+                .andExpect(jsonPath("$.amount").value(250.00));
+
+        // Balance should now be 750.00
+        Account account = accountRepository.findByUserId(userId).orElseThrow();
+        assertThat(account.getBalance()).isEqualByComparingTo("750.00");
+    }
+
+    // ── Idempotency ───────────────────────────────────────────────────────────
+
+    @Test
+    void should_return_cached_result_when_idempotency_key_is_reused() throws Exception {
+        String token = registerAndGetToken("carol", "carol@test.com", "password123");
+        UUID userId = extractUserId(token);
+        fundAccount(userId, new BigDecimal("1000.00"));
+
+        String key = UUID.randomUUID().toString();
+
+        MvcResult first = mockMvc.perform(post("/api/transactions")
+                        .header("Authorization", "Bearer " + token)
+                        .header("Idempotency-Key", key)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(transactionBody("100.00", "PAYMENT", "First attempt")))
+                .andExpect(status().isCreated())
+                .andReturn();
+
+        MvcResult second = mockMvc.perform(post("/api/transactions")
+                        .header("Authorization", "Bearer " + token)
+                        .header("Idempotency-Key", key)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(transactionBody("100.00", "PAYMENT", "Second attempt")))
+                .andExpect(status().isCreated())
+                .andReturn();
+
+        String firstId  = objectMapper.readTree(first.getResponse().getContentAsString()).get("id").asText();
+        String secondId = objectMapper.readTree(second.getResponse().getContentAsString()).get("id").asText();
+
+        assertThat(firstId).isEqualTo(secondId);
+
+        // Balance should only be deducted once
+        Account account = accountRepository.findByUserId(userId).orElseThrow();
+        assertThat(account.getBalance()).isEqualByComparingTo("900.00");
+    }
+
+    // ── Error cases ───────────────────────────────────────────────────────────
+
+    @Test
+    void should_reject_payment_when_balance_is_insufficient() throws Exception {
+        String token = registerAndGetToken("dave", "dave@test.com", "password123");
+        // New user has 0 balance — any payment should fail
+
+        mockMvc.perform(post("/api/transactions")
+                        .header("Authorization", "Bearer " + token)
+                        .header("Idempotency-Key", UUID.randomUUID().toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(transactionBody("100.00", "PAYMENT", null)))
+                .andExpect(status().isUnprocessableEntity())
+                .andExpect(jsonPath("$.code").value("INSUFFICIENT_FUNDS"));
+    }
+
+    @Test
+    void should_reject_when_idempotency_key_header_is_missing() throws Exception {
+        String token = registerAndGetToken("eve", "eve@test.com", "password123");
+
+        mockMvc.perform(post("/api/transactions")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(transactionBody("50.00", "DEPOSIT", null)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("MISSING_HEADER"));
+    }
+
+    @Test
+    void should_reject_unauthenticated_request() throws Exception {
+        mockMvc.perform(post("/api/transactions")
+                        .header("Idempotency-Key", UUID.randomUUID().toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(transactionBody("50.00", "DEPOSIT", null)))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void should_reject_when_amount_is_zero_or_negative() throws Exception {
+        String token = registerAndGetToken("frank", "frank@test.com", "password123");
+
+        mockMvc.perform(post("/api/transactions")
+                        .header("Authorization", "Bearer " + token)
+                        .header("Idempotency-Key", UUID.randomUUID().toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(transactionBody("-50.00", "DEPOSIT", null)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"));
+    }
+
+    @Test
+    void should_reject_when_type_is_missing() throws Exception {
+        String token = registerAndGetToken("grace", "grace@test.com", "password123");
+
+        mockMvc.perform(post("/api/transactions")
+                        .header("Authorization", "Bearer " + token)
+                        .header("Idempotency-Key", UUID.randomUUID().toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"amount\": 100}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"));
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private String registerAndGetToken(String username, String email, String password) throws Exception {
+        MvcResult result = mockMvc.perform(post("/api/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                new RegisterRequest(username, email, password))))
+                .andExpect(status().isCreated())
+                .andReturn();
+
+        return objectMapper.readTree(result.getResponse().getContentAsString())
+                .get("token").asText();
+    }
+
+    private UUID extractUserId(String token) throws Exception {
+        MvcResult result = mockMvc.perform(
+                        org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+                                .get("/api/users/me")
+                                .header("Authorization", "Bearer " + token))
+                .andReturn();
+        return UUID.fromString(
+                objectMapper.readTree(result.getResponse().getContentAsString())
+                        .get("id").asText());
+    }
+
+    private void fundAccount(UUID userId, BigDecimal amount) {
+        Account account = accountRepository.findByUserId(userId).orElseThrow();
+        account.credit(amount);
+        accountRepository.save(account);
+    }
+
+    private String transactionBody(String amount, String type, String description) throws Exception {
+        var node = objectMapper.createObjectNode();
+        node.put("amount", new java.math.BigDecimal(amount));
+        node.put("type", type);
+        if (description != null) node.put("description", description);
+        return objectMapper.writeValueAsString(node);
+    }
+}


### PR DESCRIPTION
## What this PR does
Closes #9 

Implements POST /api/transactions - the core write path of the payment service.
The account balance is updated atomically with the transaction INSERT in a single
database transaction. A pessimistic lock (SELECT FOR UPDATE) on the account row
prevents concurrent balance corruption from simultaneous requests.

## How to test
1. Register a user → get JWT
2. POST /api/transactions with type: DEPOSIT, amount: 1000, Idempotency-Key: <uuid> → 201
3. POST again with same Idempotency-Key → same transaction ID returned, balance unchanged
4. POST with type: PAYMENT, amount: 1500 → 422 INSUFFICIENT_FUNDS
5. POST without Idempotency-Key header → 400 MISSING_HEADER
6. Run TransactionCreationIntegrationTest (requires Docker)

## Technical decisions
- Balance is updated at creation time, not after gateway processing. This "holds" the
  funds immediately and prevents the user from spending the same money twice while the
  gateway is in-flight. If the gateway fails (later tasks), the balance is credited back.
- Idempotency is implemented via the existing idempotency_key column on the transactions
  table rather than the separate idempotency_keys table - sufficient for this task since
  we only need transaction-scoped idempotency, not generic HTTP response caching.
