### PR TITLE
Task/09-refund

### DIFF
--- a/backend/src/main/java/dev/cuong/payment/application/port/in/RefundTransactionUseCase.java
+++ b/backend/src/main/java/dev/cuong/payment/application/port/in/RefundTransactionUseCase.java
@@ -1,0 +1,26 @@
+package dev.cuong.payment.application.port.in;
+
+import dev.cuong.payment.application.dto.TransactionResult;
+
+import java.util.UUID;
+
+/**
+ * Input port: initiate a refund for a completed P2P transaction.
+ *
+ * <p>Refunds are only allowed from {@code SUCCESS} status. Any other status
+ * results in a 409 Conflict. The caller must own the transaction (fromAccount
+ * belongs to them); otherwise a 404 is returned so existence is not revealed.
+ *
+ * <p>The sender's account is credited immediately. The receiver-side deduction
+ * (taking money back from the recipient) is handled by the downstream consumer
+ * in Task 12 once domain events are wired in.
+ */
+public interface RefundTransactionUseCase {
+
+    /**
+     * @param userId        the authenticated user's ID — must own the transaction
+     * @param transactionId the transaction to refund
+     * @return the updated transaction in REFUNDED status
+     */
+    TransactionResult refundTransaction(UUID userId, UUID transactionId);
+}

--- a/backend/src/main/java/dev/cuong/payment/application/service/TransactionApplicationService.java
+++ b/backend/src/main/java/dev/cuong/payment/application/service/TransactionApplicationService.java
@@ -5,6 +5,7 @@ import dev.cuong.payment.application.dto.PagedResult;
 import dev.cuong.payment.application.dto.TransactionResult;
 import dev.cuong.payment.application.port.in.CreateTransactionUseCase;
 import dev.cuong.payment.application.port.in.GetTransactionUseCase;
+import dev.cuong.payment.application.port.in.RefundTransactionUseCase;
 import dev.cuong.payment.application.port.out.AccountRepository;
 import dev.cuong.payment.application.port.out.TransactionRepository;
 import dev.cuong.payment.domain.exception.AccountNotFoundException;
@@ -26,7 +27,7 @@ import java.util.UUID;
 @Service
 @RequiredArgsConstructor
 @Slf4j
-public class TransactionApplicationService implements CreateTransactionUseCase, GetTransactionUseCase {
+public class TransactionApplicationService implements CreateTransactionUseCase, GetTransactionUseCase, RefundTransactionUseCase {
 
     private final TransactionRepository transactionRepository;
     private final AccountRepository accountRepository;
@@ -116,6 +117,35 @@ public class TransactionApplicationService implements CreateTransactionUseCase, 
         return transactionRepository.findByIdAndFromAccountId(transactionId, fromAccountId)
                 .map(this::toResult)
                 .orElseThrow(() -> new TransactionNotFoundException(transactionId));
+    }
+
+    @Override
+    @Transactional
+    public TransactionResult refundTransaction(UUID userId, UUID transactionId) {
+        UUID fromAccountId = accountRepository.findByUserId(userId)
+                .orElseThrow(() -> new AccountNotFoundException(userId))
+                .getId();
+
+        // Scoped load — 404 if the transaction belongs to a different account
+        Transaction transaction = transactionRepository.findByIdAndFromAccountId(transactionId, fromAccountId)
+                .orElseThrow(() -> new TransactionNotFoundException(transactionId));
+
+        // State machine validates SUCCESS → REFUNDED; throws InvalidTransactionStateException otherwise
+        transaction.refund();
+
+        // Pessimistic lock on the account for the credit — prevents concurrent balance corruption
+        Account fromAccount = accountRepository.findByUserIdForUpdate(userId)
+                .orElseThrow(() -> new AccountNotFoundException(userId));
+
+        fromAccount.credit(transaction.getAmount());
+
+        transactionRepository.save(transaction);
+        accountRepository.save(fromAccount);
+
+        log.info("Refund processed: transactionId={}, fromAccountId={}, amount={}",
+                transactionId, fromAccountId, transaction.getAmount());
+
+        return toResult(transaction);
     }
 
     private TransactionResult toResult(Transaction tx) {

--- a/backend/src/main/java/dev/cuong/payment/presentation/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/dev/cuong/payment/presentation/exception/GlobalExceptionHandler.java
@@ -11,6 +11,7 @@ import dev.cuong.payment.domain.exception.SameAccountTransferException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingRequestHeaderException;
@@ -62,6 +63,14 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ApiError> handleInvalidState(InvalidTransactionStateException e) {
         return ResponseEntity.status(HttpStatus.CONFLICT)
                 .body(new ApiError("INVALID_TRANSACTION_STATE", e.getMessage()));
+    }
+
+    @ExceptionHandler(ObjectOptimisticLockingFailureException.class)
+    public ResponseEntity<ApiError> handleOptimisticLock(ObjectOptimisticLockingFailureException e) {
+        log.warn("Optimistic lock conflict on {}: {}", e.getPersistentClassName(), e.getMessage());
+        return ResponseEntity.status(HttpStatus.CONFLICT)
+                .body(new ApiError("CONFLICT_CONCURRENT_UPDATE",
+                        "The operation conflicted with a concurrent update. Please retry."));
     }
 
     @ExceptionHandler(MissingRequestHeaderException.class)

--- a/backend/src/main/java/dev/cuong/payment/presentation/transaction/TransactionController.java
+++ b/backend/src/main/java/dev/cuong/payment/presentation/transaction/TransactionController.java
@@ -5,6 +5,7 @@ import dev.cuong.payment.application.dto.PagedResult;
 import dev.cuong.payment.application.dto.TransactionResult;
 import dev.cuong.payment.application.port.in.CreateTransactionUseCase;
 import dev.cuong.payment.application.port.in.GetTransactionUseCase;
+import dev.cuong.payment.application.port.in.RefundTransactionUseCase;
 import dev.cuong.payment.domain.vo.TransactionStatus;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -26,6 +27,7 @@ public class TransactionController {
 
     private final CreateTransactionUseCase createTransactionUseCase;
     private final GetTransactionUseCase getTransactionUseCase;
+    private final RefundTransactionUseCase refundTransactionUseCase;
 
     /**
      * Creates a P2P transaction: debits the sender's account and creates a PENDING record.
@@ -96,6 +98,24 @@ public class TransactionController {
 
         return ResponseEntity.ok(
                 toResponse(getTransactionUseCase.getMyTransaction(userId, transactionId)));
+    }
+
+    /**
+     * Initiates a refund for a completed transaction — only allowed from {@code SUCCESS} status.
+     * Credits the original sender's account immediately. The receiver-side deduction is handled
+     * by the async consumer in Task 12.
+     *
+     * @return 200 with transaction in REFUNDED status; 404 if not found or owned by another user;
+     *         409 if not in SUCCESS status or a concurrent refund was already processed;
+     *         401 if unauthenticated
+     */
+    @PostMapping("/{transactionId}/refund")
+    public ResponseEntity<TransactionResponse> refundTransaction(
+            @AuthenticationPrincipal UUID userId,
+            @PathVariable UUID transactionId) {
+
+        return ResponseEntity.ok(
+                toResponse(refundTransactionUseCase.refundTransaction(userId, transactionId)));
     }
 
     private TransactionResponse toResponse(TransactionResult r) {

--- a/backend/src/test/java/dev/cuong/payment/presentation/transaction/RefundIntegrationTest.java
+++ b/backend/src/test/java/dev/cuong/payment/presentation/transaction/RefundIntegrationTest.java
@@ -1,0 +1,218 @@
+package dev.cuong.payment.presentation.transaction;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.cuong.payment.application.port.out.AccountRepository;
+import dev.cuong.payment.application.port.out.TransactionRepository;
+import dev.cuong.payment.domain.model.Account;
+import dev.cuong.payment.domain.model.Transaction;
+import dev.cuong.payment.presentation.auth.RegisterRequest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.transaction.annotation.Transactional;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Testcontainers
+@Transactional
+@TestPropertySource(properties = {
+        "spring.autoconfigure.exclude=" +
+                "org.redisson.spring.starter.RedissonAutoConfigurationV2," +
+                "org.springframework.boot.autoconfigure.kafka.KafkaAutoConfiguration",
+        "spring.flyway.enabled=true",
+        "app.jwt.secret=test-secret-key-minimum-32-chars-for-hs256!"
+})
+class RefundIntegrationTest {
+
+    @Container
+    @ServiceConnection
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:15-alpine");
+
+    @Autowired MockMvc mockMvc;
+    @Autowired ObjectMapper objectMapper;
+    @Autowired AccountRepository accountRepository;
+    @Autowired TransactionRepository transactionRepository;
+
+    // ── Happy path ────────────────────────────────────────────────────────────
+
+    @Test
+    void should_refund_transaction_and_restore_sender_balance() throws Exception {
+        String senderToken   = registerAndGetToken("alice", "alice@test.com");
+        String receiverToken = registerAndGetToken("bob",   "bob@test.com");
+        UUID senderUserId    = extractUserId(senderToken);
+        UUID toAccountId     = accountRepository.findByUserId(extractUserId(receiverToken)).orElseThrow().getId();
+
+        fundAccount(senderUserId, new BigDecimal("500.00"));
+
+        String txId = createTransaction(senderToken, toAccountId, "200.00");
+
+        // Advance transaction to SUCCESS (simulates Task 12 consumer — not yet implemented)
+        advanceToSuccess(UUID.fromString(txId));
+
+        // Sender balance after debit: 300.00
+        assertThat(accountRepository.findByUserId(senderUserId).orElseThrow().getBalance())
+                .isEqualByComparingTo("300.00");
+
+        mockMvc.perform(post("/api/transactions/" + txId + "/refund")
+                        .header("Authorization", "Bearer " + senderToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(txId))
+                .andExpect(jsonPath("$.status").value("REFUNDED"))
+                .andExpect(jsonPath("$.refundedAt").isNotEmpty());
+
+        // Balance fully restored after refund
+        assertThat(accountRepository.findByUserId(senderUserId).orElseThrow().getBalance())
+                .isEqualByComparingTo("500.00");
+    }
+
+    // ── Error cases ───────────────────────────────────────────────────────────
+
+    @Test
+    void should_reject_refund_when_transaction_is_pending() throws Exception {
+        String senderToken   = registerAndGetToken("carol", "carol@test.com");
+        String receiverToken = registerAndGetToken("dave",  "dave@test.com");
+        UUID senderUserId    = extractUserId(senderToken);
+        UUID toAccountId     = accountRepository.findByUserId(extractUserId(receiverToken)).orElseThrow().getId();
+
+        fundAccount(senderUserId, new BigDecimal("500.00"));
+        String txId = createTransaction(senderToken, toAccountId, "100.00");
+
+        // Transaction is PENDING — state machine rejects PENDING → REFUNDED
+        mockMvc.perform(post("/api/transactions/" + txId + "/refund")
+                        .header("Authorization", "Bearer " + senderToken))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("INVALID_TRANSACTION_STATE"));
+    }
+
+    @Test
+    void should_reject_double_refund() throws Exception {
+        String senderToken   = registerAndGetToken("eve",  "eve@test.com");
+        String receiverToken = registerAndGetToken("fred", "fred@test.com");
+        UUID senderUserId    = extractUserId(senderToken);
+        UUID toAccountId     = accountRepository.findByUserId(extractUserId(receiverToken)).orElseThrow().getId();
+
+        fundAccount(senderUserId, new BigDecimal("500.00"));
+        String txId = createTransaction(senderToken, toAccountId, "100.00");
+        advanceToSuccess(UUID.fromString(txId));
+
+        // First refund — succeeds
+        mockMvc.perform(post("/api/transactions/" + txId + "/refund")
+                        .header("Authorization", "Bearer " + senderToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("REFUNDED"));
+
+        // Second refund on the same transaction — state machine rejects REFUNDED → REFUNDED
+        mockMvc.perform(post("/api/transactions/" + txId + "/refund")
+                        .header("Authorization", "Bearer " + senderToken))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("INVALID_TRANSACTION_STATE"));
+    }
+
+    @Test
+    void should_return_404_when_refunding_another_users_transaction() throws Exception {
+        String aliceToken    = registerAndGetToken("alice2", "alice2@test.com");
+        String bobToken      = registerAndGetToken("bob2",   "bob2@test.com");
+        UUID aliceUserId     = extractUserId(aliceToken);
+        UUID toAccountId     = accountRepository.findByUserId(extractUserId(bobToken)).orElseThrow().getId();
+
+        fundAccount(aliceUserId, new BigDecimal("500.00"));
+        String txId = createTransaction(aliceToken, toAccountId, "100.00");
+        advanceToSuccess(UUID.fromString(txId));
+
+        // Bob tries to refund Alice's transaction — must get 404, not 403
+        mockMvc.perform(post("/api/transactions/" + txId + "/refund")
+                        .header("Authorization", "Bearer " + bobToken))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("NOT_FOUND"));
+    }
+
+    @Test
+    void should_return_404_when_transaction_does_not_exist() throws Exception {
+        String token = registerAndGetToken("grace", "grace@test.com");
+
+        mockMvc.perform(post("/api/transactions/" + UUID.randomUUID() + "/refund")
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("NOT_FOUND"));
+    }
+
+    @Test
+    void should_return_401_when_unauthenticated() throws Exception {
+        mockMvc.perform(post("/api/transactions/" + UUID.randomUUID() + "/refund"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private String registerAndGetToken(String username, String email) throws Exception {
+        MvcResult result = mockMvc.perform(post("/api/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                new RegisterRequest(username, email, "password123"))))
+                .andExpect(status().isCreated())
+                .andReturn();
+        return objectMapper.readTree(result.getResponse().getContentAsString()).get("token").asText();
+    }
+
+    private UUID extractUserId(String token) throws Exception {
+        MvcResult result = mockMvc.perform(get("/api/users/me")
+                        .header("Authorization", "Bearer " + token))
+                .andReturn();
+        return UUID.fromString(
+                objectMapper.readTree(result.getResponse().getContentAsString()).get("id").asText());
+    }
+
+    private void fundAccount(UUID userId, BigDecimal amount) {
+        Account account = accountRepository.findByUserId(userId).orElseThrow();
+        account.credit(amount);
+        accountRepository.save(account);
+    }
+
+    private String createTransaction(String senderToken, UUID toAccountId, String amount) throws Exception {
+        var node = objectMapper.createObjectNode();
+        node.put("toAccountId", toAccountId.toString());
+        node.put("amount", new BigDecimal(amount));
+
+        MvcResult result = mockMvc.perform(post("/api/transactions")
+                        .header("Authorization", "Bearer " + senderToken)
+                        .header("Idempotency-Key", UUID.randomUUID().toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(node)))
+                .andExpect(status().isCreated())
+                .andReturn();
+
+        return objectMapper.readTree(result.getResponse().getContentAsString()).get("id").asText();
+    }
+
+    /**
+     * Advances a transaction through PENDING → PROCESSING → SUCCESS.
+     * Simulates what the Kafka consumer will do in Task 12.
+     */
+    private void advanceToSuccess(UUID transactionId) {
+        Transaction tx = transactionRepository.findById(transactionId).orElseThrow();
+        tx.startProcessing();
+        transactionRepository.save(tx);
+
+        Transaction processing = transactionRepository.findById(transactionId).orElseThrow();
+        processing.complete("test-gateway-ref-" + transactionId);
+        transactionRepository.save(processing);
+    }
+}


### PR DESCRIPTION
## What this PR does
Closes #11 

Implements POST /api/transactions/{id}/refund - the reversal path for completed P2P transfers.

- **State machine enforcement:** `transaction.refund()` calls `TransactionStatus.transitionTo(REFUNDED)`,
  which checks the `ALLOWED_TRANSITIONS` map. PENDING → REFUNDED and REFUNDED → REFUNDED both throw
  `InvalidTransactionStateException` → 409 `INVALID_TRANSACTION_STATE`. No explicit status checks in
  the service — the domain model is the single source of truth.
- **Double-refund protection via optimistic locking:** Two concurrent refund requests that both read
  the transaction in SUCCESS state will both try to save it as REFUNDED. The second save fails with
  `ObjectOptimisticLockingFailureException` (JPA's `@Version` mechanism) → 409 `CONFLICT_CONCURRENT_UPDATE`.
- **Cross-user security:** Uses `findByIdAndFromAccountId(transactionId, fromAccountId)` — 404 for
  transactions owned by other users (same don't-leak-existence pattern as Task 08).
- **Balance credit:** Acquires pessimistic write lock on `fromAccount` before crediting — same lock
  pattern as Task 07's debit to prevent concurrent balance corruption.

## How to test
1. `./gradlew :backend:test --tests "*.RefundIntegrationTest"`
2. Register → fund → create tx → advance to SUCCESS (test helper) → refund → balance restored
3. Refund PENDING tx → 409 INVALID_TRANSACTION_STATE
4. Refund twice → 409 INVALID_TRANSACTION_STATE on second attempt
5. Bob refunds Alice's tx → 404 NOT_FOUND