### PR TITLE
Task/10-rate-limiting

### DIFF
--- a/backend/src/main/java/dev/cuong/payment/domain/exception/RateLimitExceededException.java
+++ b/backend/src/main/java/dev/cuong/payment/domain/exception/RateLimitExceededException.java
@@ -1,0 +1,10 @@
+package dev.cuong.payment.domain.exception;
+
+import java.util.UUID;
+
+public class RateLimitExceededException extends DomainException {
+
+    public RateLimitExceededException(UUID userId) {
+        super("Rate limit exceeded for user: " + userId + ". Max 10 requests per 60 seconds.");
+    }
+}

--- a/backend/src/main/java/dev/cuong/payment/infrastructure/config/SecurityConfig.java
+++ b/backend/src/main/java/dev/cuong/payment/infrastructure/config/SecurityConfig.java
@@ -1,5 +1,8 @@
 package dev.cuong.payment.infrastructure.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.cuong.payment.application.port.out.RateLimiter;
+import dev.cuong.payment.infrastructure.ratelimit.RateLimitFilter;
 import dev.cuong.payment.infrastructure.security.JwtAuthenticationFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -21,6 +24,8 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final RateLimiter rateLimiter;
+    private final ObjectMapper objectMapper;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -33,6 +38,8 @@ public class SecurityConfig {
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+                // Rate limit runs after JWT sets the principal in the SecurityContext
+                .addFilterAfter(new RateLimitFilter(rateLimiter, objectMapper), JwtAuthenticationFilter.class)
                 .build();
     }
 

--- a/backend/src/main/java/dev/cuong/payment/infrastructure/ratelimit/RateLimitFilter.java
+++ b/backend/src/main/java/dev/cuong/payment/infrastructure/ratelimit/RateLimitFilter.java
@@ -1,0 +1,90 @@
+package dev.cuong.payment.infrastructure.ratelimit;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.cuong.payment.application.port.out.RateLimiter;
+import dev.cuong.payment.presentation.exception.ApiError;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.lang.NonNull;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.UUID;
+
+/**
+ * Applies a per-user sliding-window rate limit to {@code POST /api/transactions}.
+ *
+ * <p>This filter runs after {@code JwtAuthenticationFilter}, so the userId is already
+ * available in the {@code SecurityContext}. Unauthenticated requests are passed through
+ * (the downstream security layer will return 401).
+ *
+ * <p>When the limit is exceeded the filter writes a 429 JSON response directly — it does
+ * not throw an exception, because {@code @RestControllerAdvice} only handles exceptions
+ * inside the {@code DispatcherServlet}, not from filters.
+ */
+@RequiredArgsConstructor
+@Slf4j
+public class RateLimitFilter extends OncePerRequestFilter {
+
+    private static final String RATE_LIMITED_PATH = "/api/transactions";
+    private static final long RETRY_AFTER_SECONDS = 60L;
+
+    private final RateLimiter rateLimiter;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    protected void doFilterInternal(
+            @NonNull HttpServletRequest request,
+            @NonNull HttpServletResponse response,
+            @NonNull FilterChain filterChain) throws ServletException, IOException {
+
+        if (!isRateLimitedEndpoint(request)) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        UUID userId = extractUserId();
+        if (userId == null) {
+            // Unauthenticated request — pass through; 401 handled by Spring Security
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        if (rateLimiter.tryConsume(userId)) {
+            filterChain.doFilter(request, response);
+        } else {
+            sendRateLimitResponse(response, userId);
+        }
+    }
+
+    private boolean isRateLimitedEndpoint(HttpServletRequest request) {
+        return HttpMethod.POST.matches(request.getMethod())
+                && RATE_LIMITED_PATH.equals(request.getRequestURI());
+    }
+
+    private UUID extractUserId() {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth == null || !auth.isAuthenticated() || !(auth.getPrincipal() instanceof UUID userId)) {
+            return null;
+        }
+        return userId;
+    }
+
+    private void sendRateLimitResponse(HttpServletResponse response, UUID userId) throws IOException {
+        log.warn("Rate limit response sent: userId={}", userId);
+        response.setStatus(429);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setHeader("Retry-After", String.valueOf(RETRY_AFTER_SECONDS));
+        ApiError error = new ApiError("RATE_LIMIT_EXCEEDED",
+                "Too many requests. You may send at most 10 transactions per 60 seconds.");
+        response.getWriter().write(objectMapper.writeValueAsString(error));
+    }
+}

--- a/backend/src/main/java/dev/cuong/payment/infrastructure/ratelimit/RateLimiterConfig.java
+++ b/backend/src/main/java/dev/cuong/payment/infrastructure/ratelimit/RateLimiterConfig.java
@@ -1,0 +1,44 @@
+package dev.cuong.payment.infrastructure.ratelimit;
+
+import dev.cuong.payment.application.port.out.RateLimiter;
+import lombok.extern.slf4j.Slf4j;
+import org.redisson.api.RedissonClient;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Wires the appropriate {@link RateLimiter} bean depending on whether Redis is available.
+ *
+ * <p>When {@link RedissonClient} is present (production + rate-limit integration tests),
+ * the full sliding-window implementation is used. When Redisson is excluded (unit and
+ * service integration tests that exclude Redis), a no-op implementation is used so
+ * those tests don't require a Redis container and the application context still starts.
+ *
+ * <p>This is the "fail-open" resilience pattern: if the rate limiter infrastructure is
+ * unavailable, we allow traffic rather than blocking everything. In production, a
+ * Resilience4j circuit breaker on the Redis calls can add a second safety layer.
+ */
+@Configuration
+@Slf4j
+public class RateLimiterConfig {
+
+    @Bean
+    @ConditionalOnBean(RedissonClient.class)
+    public RateLimiter redisRateLimiter(
+            RedissonClient redissonClient,
+            @Value("${app.rate-limit.max-requests-per-minute:10}") int maxRequests,
+            @Value("${app.rate-limit.window-seconds:60}") long windowSeconds) {
+        log.info("Rate limiter: Redis sliding-window (limit={}, window={}s)", maxRequests, windowSeconds);
+        return new RedisRateLimiter(redissonClient, maxRequests, windowSeconds);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(RateLimiter.class)
+    public RateLimiter noOpRateLimiter() {
+        log.warn("Rate limiter: no-op (Redis unavailable — all requests allowed)");
+        return userId -> true;
+    }
+}

--- a/backend/src/main/java/dev/cuong/payment/infrastructure/ratelimit/RedisRateLimiter.java
+++ b/backend/src/main/java/dev/cuong/payment/infrastructure/ratelimit/RedisRateLimiter.java
@@ -1,0 +1,89 @@
+package dev.cuong.payment.infrastructure.ratelimit;
+
+import dev.cuong.payment.application.port.out.RateLimiter;
+import lombok.extern.slf4j.Slf4j;
+import org.redisson.api.RScript;
+import org.redisson.api.RedissonClient;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Redis sliding-window rate limiter backed by a Lua script for atomicity.
+ *
+ * <p>Key: {@code rate_limit:tx:{userId}} — one sorted set per user.
+ * Score = request timestamp (ms); member = unique request UUID.
+ * The Lua script is sent to Redis and executed as a single indivisible command,
+ * preventing any race between the count check and the ZADD.
+ *
+ * <p>Declared as a Spring bean via {@link RateLimiterConfig}, not directly annotated
+ * with {@code @Component}, so that {@code @ConditionalOnBean(RedissonClient.class)}
+ * can be applied at the configuration class level where evaluation order is reliable.
+ */
+@Slf4j
+public class RedisRateLimiter implements RateLimiter {
+
+    private static final String KEY_PREFIX = "rate_limit:tx:";
+
+    /**
+     * Sliding-window Lua script.
+     *
+     * KEYS[1] = rate limit key for the user
+     * ARGV[1] = current timestamp in milliseconds
+     * ARGV[2] = window size in milliseconds
+     * ARGV[3] = max allowed requests per window
+     * ARGV[4] = unique member for this request (prevents score collisions)
+     *
+     * Returns 1 if the request is allowed, 0 if the limit is exceeded.
+     */
+    private static final String SCRIPT = """
+            local key = KEYS[1]
+            local now = tonumber(ARGV[1])
+            local window_ms = tonumber(ARGV[2])
+            local limit = tonumber(ARGV[3])
+            local member = ARGV[4]
+            redis.call('ZREMRANGEBYSCORE', key, '-inf', now - window_ms)
+            local count = redis.call('ZCARD', key)
+            if count >= limit then
+                return 0
+            end
+            redis.call('ZADD', key, now, member)
+            redis.call('EXPIRE', key, math.ceil(window_ms / 1000) + 10)
+            return 1
+            """;
+
+    private final RedissonClient redissonClient;
+    private final int maxRequests;
+    private final long windowSeconds;
+
+    public RedisRateLimiter(RedissonClient redissonClient, int maxRequests, long windowSeconds) {
+        this.redissonClient = redissonClient;
+        this.maxRequests = maxRequests;
+        this.windowSeconds = windowSeconds;
+    }
+
+    @Override
+    public boolean tryConsume(UUID userId) {
+        String key = KEY_PREFIX + userId;
+        long nowMs = System.currentTimeMillis();
+        long windowMs = windowSeconds * 1000;
+        String member = UUID.randomUUID().toString();
+
+        RScript script = redissonClient.getScript();
+        Long result = script.eval(
+                RScript.Mode.READ_WRITE,
+                SCRIPT,
+                RScript.ReturnType.INTEGER,
+                List.of(key),
+                String.valueOf(nowMs),
+                String.valueOf(windowMs),
+                String.valueOf(maxRequests),
+                member);
+
+        boolean allowed = Long.valueOf(1L).equals(result);
+        if (!allowed) {
+            log.warn("Rate limit exceeded: userId={}, limit={}/{}s", userId, maxRequests, windowSeconds);
+        }
+        return allowed;
+    }
+}

--- a/backend/src/main/java/dev/cuong/payment/presentation/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/dev/cuong/payment/presentation/exception/GlobalExceptionHandler.java
@@ -7,6 +7,7 @@ import dev.cuong.payment.domain.exception.TransactionNotFoundException;
 import dev.cuong.payment.domain.exception.UserAlreadyExistsException;
 import dev.cuong.payment.domain.exception.UserNotFoundException;
 import dev.cuong.payment.domain.exception.InsufficientFundsException;
+import dev.cuong.payment.domain.exception.RateLimitExceededException;
 import dev.cuong.payment.domain.exception.SameAccountTransferException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -57,6 +58,13 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ApiError> handleInsufficientFunds(InsufficientFundsException e) {
         return ResponseEntity.status(HttpStatus.UNPROCESSABLE_ENTITY)
                 .body(new ApiError("INSUFFICIENT_FUNDS", e.getMessage()));
+    }
+
+    @ExceptionHandler(RateLimitExceededException.class)
+    public ResponseEntity<ApiError> handleRateLimit(RateLimitExceededException e) {
+        return ResponseEntity.status(429)
+                .header("Retry-After", "60")
+                .body(new ApiError("RATE_LIMIT_EXCEEDED", e.getMessage()));
     }
 
     @ExceptionHandler(InvalidTransactionStateException.class)

--- a/backend/src/test/java/dev/cuong/payment/infrastructure/ratelimit/RateLimitIntegrationTest.java
+++ b/backend/src/test/java/dev/cuong/payment/infrastructure/ratelimit/RateLimitIntegrationTest.java
@@ -1,0 +1,252 @@
+package dev.cuong.payment.infrastructure.ratelimit;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.cuong.payment.application.port.out.AccountRepository;
+import dev.cuong.payment.domain.model.Account;
+import dev.cuong.payment.presentation.auth.RegisterRequest;
+import org.junit.jupiter.api.Test;
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.transaction.annotation.Transactional;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Testcontainers
+@Transactional
+@TestPropertySource(properties = {
+        // Exclude only Kafka — Redisson is excluded too and replaced by @TestConfiguration below
+        "spring.autoconfigure.exclude=" +
+                "org.redisson.spring.starter.RedissonAutoConfigurationV2," +
+                "org.springframework.boot.autoconfigure.kafka.KafkaAutoConfiguration",
+        "spring.flyway.enabled=true",
+        "app.jwt.secret=test-secret-key-minimum-32-chars-for-hs256!",
+        // Lower limit to 3 so the test completes quickly without sending 10 real requests
+        "app.rate-limit.max-requests-per-minute=3",
+        "app.rate-limit.window-seconds=60"
+})
+class RateLimitIntegrationTest {
+
+    @Container
+    @ServiceConnection
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:15-alpine");
+
+    @Container
+    @SuppressWarnings("resource")
+    static GenericContainer<?> redis = new GenericContainer<>("redis:7-alpine")
+            .withExposedPorts(6379);
+
+    @DynamicPropertySource
+    static void redisProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.data.redis.host", redis::getHost);
+        registry.add("spring.data.redis.port", () -> redis.getMappedPort(6379));
+    }
+
+    @TestConfiguration
+    static class TestRedissonConfig {
+        @Bean
+        @Primary
+        RedissonClient testRedissonClient() {
+            Config config = new Config();
+            config.useSingleServer()
+                    .setAddress("redis://" + redis.getHost() + ":" + redis.getMappedPort(6379))
+                    .setConnectionPoolSize(4)
+                    .setConnectionMinimumIdleSize(1);
+            return Redisson.create(config);
+        }
+    }
+
+    @Autowired MockMvc mockMvc;
+    @Autowired ObjectMapper objectMapper;
+    @Autowired AccountRepository accountRepository;
+
+    // ── Happy path: under the limit ───────────────────────────────────────────
+
+    @Test
+    void should_allow_requests_within_rate_limit() throws Exception {
+        String senderToken   = registerAndGetToken("alice", "alice@test.com");
+        String receiverToken = registerAndGetToken("bob",   "bob@test.com");
+        UUID senderUserId    = extractUserId(senderToken);
+        UUID toAccountId     = accountRepository.findByUserId(extractUserId(receiverToken)).orElseThrow().getId();
+
+        fundAccount(senderUserId, new BigDecimal("5000.00"));
+
+        // 3 requests = exactly at the limit configured in test properties (limit=3)
+        for (int i = 0; i < 3; i++) {
+            mockMvc.perform(post("/api/transactions")
+                            .header("Authorization", "Bearer " + senderToken)
+                            .header("Idempotency-Key", UUID.randomUUID().toString())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(txBody(toAccountId, "10.00")))
+                    .andExpect(status().isCreated());
+        }
+    }
+
+    // ── Rate limit exceeded ───────────────────────────────────────────────────
+
+    @Test
+    void should_return_429_when_rate_limit_exceeded() throws Exception {
+        String senderToken   = registerAndGetToken("carol", "carol@test.com");
+        String receiverToken = registerAndGetToken("dave",  "dave@test.com");
+        UUID senderUserId    = extractUserId(senderToken);
+        UUID toAccountId     = accountRepository.findByUserId(extractUserId(receiverToken)).orElseThrow().getId();
+
+        fundAccount(senderUserId, new BigDecimal("5000.00"));
+
+        // Send limit (3) requests — all should succeed
+        for (int i = 0; i < 3; i++) {
+            mockMvc.perform(post("/api/transactions")
+                            .header("Authorization", "Bearer " + senderToken)
+                            .header("Idempotency-Key", UUID.randomUUID().toString())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(txBody(toAccountId, "10.00")))
+                    .andExpect(status().isCreated());
+        }
+
+        // The 4th request (limit + 1) must be rejected
+        mockMvc.perform(post("/api/transactions")
+                        .header("Authorization", "Bearer " + senderToken)
+                        .header("Idempotency-Key", UUID.randomUUID().toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(txBody(toAccountId, "10.00")))
+                .andExpect(status().is(429))
+                .andExpect(header().string("Retry-After", "60"))
+                .andExpect(jsonPath("$.code").value("RATE_LIMIT_EXCEEDED"));
+    }
+
+    // ── User isolation ────────────────────────────────────────────────────────
+
+    @Test
+    void should_not_affect_other_users_when_one_user_is_rate_limited() throws Exception {
+        String aliceToken    = registerAndGetToken("alice2", "alice2@test.com");
+        String bobToken      = registerAndGetToken("bob2",   "bob2@test.com");
+        String carolToken    = registerAndGetToken("carol2", "carol2@test.com");
+        UUID aliceUserId     = extractUserId(aliceToken);
+        UUID bobUserId       = extractUserId(bobToken);
+        UUID carolToAccountId = accountRepository.findByUserId(extractUserId(carolToken)).orElseThrow().getId();
+
+        fundAccount(aliceUserId, new BigDecimal("5000.00"));
+        fundAccount(bobUserId, new BigDecimal("5000.00"));
+
+        // Exhaust Alice's rate limit
+        for (int i = 0; i < 3; i++) {
+            mockMvc.perform(post("/api/transactions")
+                            .header("Authorization", "Bearer " + aliceToken)
+                            .header("Idempotency-Key", UUID.randomUUID().toString())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(txBody(carolToAccountId, "10.00")))
+                    .andExpect(status().isCreated());
+        }
+
+        // Alice is now rate limited
+        mockMvc.perform(post("/api/transactions")
+                        .header("Authorization", "Bearer " + aliceToken)
+                        .header("Idempotency-Key", UUID.randomUUID().toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(txBody(carolToAccountId, "10.00")))
+                .andExpect(status().is(429));
+
+        // Bob's requests are unaffected — his bucket is independent
+        mockMvc.perform(post("/api/transactions")
+                        .header("Authorization", "Bearer " + bobToken)
+                        .header("Idempotency-Key", UUID.randomUUID().toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(txBody(carolToAccountId, "10.00")))
+                .andExpect(status().isCreated());
+    }
+
+    // ── Rate limiting only on transaction endpoint ────────────────────────────
+
+    @Test
+    void should_not_rate_limit_non_transaction_endpoints() throws Exception {
+        String senderToken   = registerAndGetToken("eve",  "eve@test.com");
+        String receiverToken = registerAndGetToken("fred", "fred@test.com");
+        UUID senderUserId    = extractUserId(senderToken);
+        UUID toAccountId     = accountRepository.findByUserId(extractUserId(receiverToken)).orElseThrow().getId();
+
+        fundAccount(senderUserId, new BigDecimal("5000.00"));
+
+        // Exhaust rate limit
+        for (int i = 0; i < 3; i++) {
+            mockMvc.perform(post("/api/transactions")
+                            .header("Authorization", "Bearer " + senderToken)
+                            .header("Idempotency-Key", UUID.randomUUID().toString())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(txBody(toAccountId, "10.00")))
+                    .andExpect(status().isCreated());
+        }
+
+        // Rate limited on POST /api/transactions
+        mockMvc.perform(post("/api/transactions")
+                        .header("Authorization", "Bearer " + senderToken)
+                        .header("Idempotency-Key", UUID.randomUUID().toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(txBody(toAccountId, "10.00")))
+                .andExpect(status().is(429));
+
+        // GET /api/transactions is NOT rate limited — should still work
+        mockMvc.perform(get("/api/transactions")
+                        .header("Authorization", "Bearer " + senderToken))
+                .andExpect(status().isOk());
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private String registerAndGetToken(String username, String email) throws Exception {
+        MvcResult result = mockMvc.perform(post("/api/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                new RegisterRequest(username, email, "password123"))))
+                .andExpect(status().isCreated())
+                .andReturn();
+        return objectMapper.readTree(result.getResponse().getContentAsString()).get("token").asText();
+    }
+
+    private UUID extractUserId(String token) throws Exception {
+        MvcResult result = mockMvc.perform(get("/api/users/me")
+                        .header("Authorization", "Bearer " + token))
+                .andReturn();
+        return UUID.fromString(
+                objectMapper.readTree(result.getResponse().getContentAsString()).get("id").asText());
+    }
+
+    private void fundAccount(UUID userId, BigDecimal amount) {
+        Account account = accountRepository.findByUserId(userId).orElseThrow();
+        account.credit(amount);
+        accountRepository.save(account);
+    }
+
+    private String txBody(UUID toAccountId, String amount) throws Exception {
+        var node = objectMapper.createObjectNode();
+        node.put("toAccountId", toAccountId.toString());
+        node.put("amount", new BigDecimal(amount));
+        return objectMapper.writeValueAsString(node);
+    }
+}


### PR DESCRIPTION
## What this PR does
Closes #12 

Adds per-user rate limiting on POST /api/transactions using a Redis sliding-window algorithm.

- **Sliding window (not token bucket):** Token bucket refills at a fixed rate regardless of request timing,
  which can allow bursts. Sliding window tracks the actual timestamp of each request in a Redis sorted
  set - if 10 requests arrived in the last 60 seconds, the 11th is rejected regardless of when it came.
- **Atomic Lua script:** `ZREMRANGEBYSCORE + ZCARD + ZADD + EXPIRE` in one Redis server-side script.
  No two threads can interleave between the count check and the ZADD - same atomicity guarantee as
  a database transaction, at Redis speed.
- **Fail-open:** `RateLimiterConfig` provides a no-op implementation when `RedissonClient` is absent
  (test environments that exclude Redis). This is the industry-standard pattern: rate limiter
  infrastructure failure should not take down the service.
- **Filter placement:** `RateLimitFilter` runs AFTER `JwtAuthenticationFilter` so the userId is already
  in the `SecurityContext`. Unauthenticated requests skip rate limiting (they'll get 401 from Spring Security).
- **429 written directly:** `@RestControllerAdvice` only catches exceptions inside `DispatcherServlet`.
  Since the filter runs before the servlet, the filter writes the JSON 429 response directly.

## How to test
0. `cd backend`
1. `./gradlew :backend:test --tests "*.RateLimitIntegrationTest"`
2. Start Redis: `docker-compose up -d redis`
3. `POST /api/transactions` × 3 → all 201 (limit=3 in test, 10 in prod)
4. `POST /api/transactions` #4 → 429 with `Retry-After: 60`
5. Different user → unaffected by Alice's rate limit

## Technical decisions
- Used `OncePerRequestFilter` with direct response write instead of throwing from filter - the exception
  handler advice cannot intercept filter-layer exceptions.
- `rate_limit:tx:{userId}` key design allows O(1) lookup per user and natural TTL cleanup.
- `@ConditionalOnBean` / `@ConditionalOnMissingBean` for conditional wiring - avoids test contamination
  without requiring every test to provide a mock `RateLimiter`.