### PR TITLE
Task/12-processing-consumer

### DIFF
--- a/backend/bin/main/application.yml
+++ b/backend/bin/main/application.yml
@@ -124,8 +124,10 @@ resilience4j:
         max-attempts: 3
         wait-duration: 1s
         exponential-backoff-multiplier: 2.0   # 1s → 2s → 4s
-        # retry-exceptions and ignore-exceptions reference gateway exception classes
-        # created in Task 12 — wired in at that point
+        retry-exceptions:
+          - dev.cuong.payment.domain.exception.PaymentGatewayTimeoutException
+        ignore-exceptions:
+          - dev.cuong.payment.domain.exception.PaymentGatewayException
 
 # ── Logging ─────────────────────────────────────────────────────────────────────
 logging:

--- a/backend/src/main/java/dev/cuong/payment/application/port/out/AccountRepository.java
+++ b/backend/src/main/java/dev/cuong/payment/application/port/out/AccountRepository.java
@@ -25,5 +25,12 @@ public interface AccountRepository {
      */
     Optional<Account> findByUserIdForUpdate(UUID userId);
 
+    /**
+     * Finds the account by its own ID and acquires a pessimistic write lock.
+     * Used by the Kafka consumer which has an {@code accountId} from the event message,
+     * not a {@code userId} from the JWT context.
+     */
+    Optional<Account> findByIdForUpdate(UUID accountId);
+
     Account save(Account account);
 }

--- a/backend/src/main/java/dev/cuong/payment/application/port/out/DistributedLockPort.java
+++ b/backend/src/main/java/dev/cuong/payment/application/port/out/DistributedLockPort.java
@@ -1,0 +1,28 @@
+package dev.cuong.payment.application.port.out;
+
+/**
+ * Output port: acquire and release a cluster-wide exclusive lock.
+ *
+ * <p>Implementations are expected to be backed by a distributed store (e.g., Redis)
+ * so that multiple service instances coordinate on the same lock key.
+ * The lock auto-expires after {@code leaseSeconds} as a safety net for process crashes.
+ */
+public interface DistributedLockPort {
+
+    /**
+     * Attempts to acquire an exclusive lock on {@code key}.
+     *
+     * @param key          lock identifier (should be unique per resource)
+     * @param waitSeconds  maximum time to wait for the lock; 0 means return immediately
+     * @param leaseSeconds automatic expiry time — the lock releases even if {@link #unlock}
+     *                     is never called (crash safety)
+     * @return {@code true} if the lock was acquired, {@code false} otherwise
+     */
+    boolean tryLock(String key, long waitSeconds, long leaseSeconds);
+
+    /**
+     * Releases the lock on {@code key}.
+     * Safe to call even if the lock has already expired or was never acquired.
+     */
+    void unlock(String key);
+}

--- a/backend/src/main/java/dev/cuong/payment/application/port/out/PaymentGatewayPort.java
+++ b/backend/src/main/java/dev/cuong/payment/application/port/out/PaymentGatewayPort.java
@@ -1,0 +1,33 @@
+package dev.cuong.payment.application.port.out;
+
+import dev.cuong.payment.domain.exception.PaymentGatewayException;
+import dev.cuong.payment.domain.exception.PaymentGatewayTimeoutException;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+/**
+ * Output port: submit a payment charge to the external payment gateway.
+ *
+ * <p>Implementations are responsible for Resilience4j circuit-breaker and retry
+ * decoration. Callers should treat the thrown exceptions as described:
+ * <ul>
+ *   <li>{@link PaymentGatewayException} — permanent rejection; do not retry; mark FAILED.
+ *   <li>{@link PaymentGatewayTimeoutException} — transient failure; retry is handled by
+ *       the implementation; if still thrown after retries, mark TIMEOUT.
+ * </ul>
+ */
+public interface PaymentGatewayPort {
+
+    /**
+     * Charges the given amount through the payment gateway.
+     *
+     * @param transactionId used as a gateway-level idempotency key
+     * @param amount        amount to charge, always positive
+     * @return gateway reference string on success
+     * @throws PaymentGatewayException        if the gateway permanently rejects the charge
+     * @throws PaymentGatewayTimeoutException if the gateway does not respond in time
+     */
+    String charge(UUID transactionId, BigDecimal amount)
+            throws PaymentGatewayException, PaymentGatewayTimeoutException;
+}

--- a/backend/src/main/java/dev/cuong/payment/domain/exception/PaymentGatewayException.java
+++ b/backend/src/main/java/dev/cuong/payment/domain/exception/PaymentGatewayException.java
@@ -1,0 +1,18 @@
+package dev.cuong.payment.domain.exception;
+
+/**
+ * The external payment gateway explicitly rejected the charge.
+ *
+ * <p>This is a permanent business failure — retrying the same request will yield the
+ * same rejection (e.g., card declined, fraud block, account closed). The transaction
+ * should be marked {@code FAILED} and the sender's balance restored immediately.
+ *
+ * <p>Resilience4j retry is configured to <em>ignore</em> this exception class, so
+ * no retry is attempted. The circuit breaker still records it as a failure.
+ */
+public class PaymentGatewayException extends RuntimeException {
+
+    public PaymentGatewayException(String reason) {
+        super(reason);
+    }
+}

--- a/backend/src/main/java/dev/cuong/payment/domain/exception/PaymentGatewayTimeoutException.java
+++ b/backend/src/main/java/dev/cuong/payment/domain/exception/PaymentGatewayTimeoutException.java
@@ -1,0 +1,16 @@
+package dev.cuong.payment.domain.exception;
+
+/**
+ * The external payment gateway did not respond within the expected window.
+ *
+ * <p>This is a transient failure — the gateway may succeed on a subsequent attempt.
+ * Resilience4j retry is configured to <em>retry</em> this exception class (up to 3 times
+ * with exponential backoff: 1 s → 2 s → 4 s). After all retries are exhausted the
+ * exception propagates and the transaction is marked {@code TIMEOUT}.
+ */
+public class PaymentGatewayTimeoutException extends RuntimeException {
+
+    public PaymentGatewayTimeoutException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/dev/cuong/payment/infrastructure/gateway/GatewayProperties.java
+++ b/backend/src/main/java/dev/cuong/payment/infrastructure/gateway/GatewayProperties.java
@@ -1,0 +1,34 @@
+package dev.cuong.payment.infrastructure.gateway;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+/**
+ * Externally-configurable parameters for {@link MockPaymentGateway}.
+ *
+ * <p>In production, point {@code successRate} and related rates at environment variables
+ * so that staging/canary environments can simulate realistic failure scenarios.
+ */
+@Component
+@ConfigurationProperties(prefix = "app.gateway")
+@Getter
+@Setter
+public class GatewayProperties {
+
+    /** Probability [0, 1] that a charge succeeds. */
+    private double successRate = 0.8;
+
+    /** Probability [0, 1] that the gateway returns a permanent failure. */
+    private double failRate = 0.1;
+
+    /** Probability [0, 1] that the gateway times out (transient — retryable). */
+    private double timeoutRate = 0.1;
+
+    /** Minimum simulated processing delay in milliseconds. */
+    private int minDelayMs = 100;
+
+    /** Maximum simulated processing delay in milliseconds. */
+    private int maxDelayMs = 500;
+}

--- a/backend/src/main/java/dev/cuong/payment/infrastructure/gateway/MockPaymentGateway.java
+++ b/backend/src/main/java/dev/cuong/payment/infrastructure/gateway/MockPaymentGateway.java
@@ -1,0 +1,72 @@
+package dev.cuong.payment.infrastructure.gateway;
+
+import dev.cuong.payment.application.port.out.PaymentGatewayPort;
+import dev.cuong.payment.domain.exception.PaymentGatewayException;
+import dev.cuong.payment.domain.exception.PaymentGatewayTimeoutException;
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
+import io.github.resilience4j.retry.annotation.Retry;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.math.BigDecimal;
+import java.util.Random;
+import java.util.UUID;
+
+/**
+ * Simulated payment gateway that produces realistic success/failure/timeout distributions.
+ *
+ * <p>The {@code @CircuitBreaker} and {@code @Retry} annotations are processed by
+ * Resilience4j's Spring AOP aspect. The effective decoration order is:
+ * <pre>CircuitBreaker { Retry { charge() } }</pre>
+ * — if the circuit is OPEN, no retry is attempted (fast-fail). When CLOSED, up to
+ * {@code max-attempts} retries fire on {@link PaymentGatewayTimeoutException};
+ * {@link PaymentGatewayException} is ignored by the retry (permanent failure, fail immediately).
+ *
+ * <p>All rates are configurable via {@link GatewayProperties} / environment variables
+ * so staging/load environments can dial specific failure scenarios.
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class MockPaymentGateway implements PaymentGatewayPort {
+
+    private final GatewayProperties properties;
+    private final Random random = new Random();
+
+    @Override
+    @CircuitBreaker(name = "payment-gateway")
+    @Retry(name = "payment-gateway")
+    public String charge(UUID transactionId, BigDecimal amount)
+            throws PaymentGatewayException, PaymentGatewayTimeoutException {
+
+        simulateLatency();
+
+        double roll = random.nextDouble();
+
+        if (roll < properties.getSuccessRate()) {
+            String ref = "GW-" + UUID.randomUUID().toString().replace("-", "").substring(0, 10).toUpperCase();
+            log.debug("Gateway accepted: transactionId={}, ref={}, amount={}", transactionId, ref, amount);
+            return ref;
+        }
+
+        if (roll < properties.getSuccessRate() + properties.getFailRate()) {
+            log.debug("Gateway rejected: transactionId={}, amount={}", transactionId, amount);
+            throw new PaymentGatewayException("Payment rejected by gateway");
+        }
+
+        log.debug("Gateway timeout: transactionId={}", transactionId);
+        throw new PaymentGatewayTimeoutException("Gateway did not respond in time");
+    }
+
+    private void simulateLatency() {
+        int range = properties.getMaxDelayMs() - properties.getMinDelayMs();
+        int delay = properties.getMinDelayMs() + (range > 0 ? random.nextInt(range) : 0);
+        if (delay <= 0) return;
+        try {
+            Thread.sleep(delay);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+}

--- a/backend/src/main/java/dev/cuong/payment/infrastructure/kafka/KafkaConfig.java
+++ b/backend/src/main/java/dev/cuong/payment/infrastructure/kafka/KafkaConfig.java
@@ -9,6 +9,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.kafka.config.TopicBuilder;
 import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.listener.DefaultErrorHandler;
+import org.springframework.util.backoff.FixedBackOff;
 
 /**
  * Kafka topic declarations and {@link EventPublisher} wiring.
@@ -47,6 +49,17 @@ public class KafkaConfig {
                 .partitions(1)
                 .replicas(1)
                 .build();
+    }
+
+    /**
+     * Retries failed consumer records up to 2 times with a 1-second delay before
+     * the record is logged and discarded (or forwarded to DLQ in Task 15).
+     * {@link org.springframework.dao.OptimisticLockingFailureException} is caught inside
+     * the consumer and never propagates here — only truly unexpected failures retry.
+     */
+    @Bean
+    public DefaultErrorHandler kafkaErrorHandler() {
+        return new DefaultErrorHandler(new FixedBackOff(1000L, 2L));
     }
 
     @SuppressWarnings({"rawtypes", "unchecked"})

--- a/backend/src/main/java/dev/cuong/payment/infrastructure/kafka/TransactionProcessingConsumer.java
+++ b/backend/src/main/java/dev/cuong/payment/infrastructure/kafka/TransactionProcessingConsumer.java
@@ -1,0 +1,190 @@
+package dev.cuong.payment.infrastructure.kafka;
+
+import dev.cuong.payment.application.port.out.AccountRepository;
+import dev.cuong.payment.application.port.out.DistributedLockPort;
+import dev.cuong.payment.application.port.out.EventPublisher;
+import dev.cuong.payment.application.port.out.PaymentGatewayPort;
+import dev.cuong.payment.application.port.out.TransactionRepository;
+import dev.cuong.payment.domain.event.TransactionEventType;
+import dev.cuong.payment.domain.exception.PaymentGatewayException;
+import dev.cuong.payment.domain.exception.PaymentGatewayTimeoutException;
+import dev.cuong.payment.domain.exception.TransactionNotFoundException;
+import dev.cuong.payment.domain.model.Account;
+import dev.cuong.payment.domain.model.Transaction;
+import dev.cuong.payment.domain.vo.TransactionStatus;
+import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.OptimisticLockingFailureException;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+/**
+ * Kafka consumer that drives the payment transaction state machine from PENDING to a terminal state.
+ *
+ * <p><strong>Processing flow per CREATED event:</strong>
+ * <ol>
+ *   <li>Acquire a Redis distributed lock on {@code transactionId} (at-most-once guard across instances).
+ *   <li>In a short DB transaction: verify PENDING → save as PROCESSING (optimistic lock version check).
+ *   <li>Outside any DB transaction: call the payment gateway (circuit breaker + retry).
+ *   <li>In a second short DB transaction: record SUCCESS/FAILED/TIMEOUT, update account balances.
+ *   <li>Release the lock.
+ * </ol>
+ *
+ * <p>Two separate DB transactions are used intentionally: holding a connection open during a
+ * network call to the gateway would exhaust the connection pool under load. The gap between
+ * the two transactions is safe because the distributed lock prevents concurrent processing,
+ * and the optimistic lock prevents the edge case where the Redis lock expires mid-flight.
+ *
+ * <p>Non-CREATED events (PROCESSING, SUCCESS, FAILED, TIMEOUT, REFUNDED) are forwarded by
+ * the notification consumer (Task 13) and audit consumer (Task 14); this consumer ignores them.
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class TransactionProcessingConsumer {
+
+    private static final String LOCK_PREFIX = "lock:processing:tx:";
+    private static final long LOCK_LEASE_SECONDS = 60;
+
+    private final TransactionRepository transactionRepository;
+    private final AccountRepository accountRepository;
+    private final PaymentGatewayPort paymentGateway;
+    private final DistributedLockPort distributedLock;
+    private final EventPublisher eventPublisher;
+    private final PlatformTransactionManager transactionManager;
+
+    // TransactionTemplate is derived from transactionManager — not a Spring bean itself.
+    private TransactionTemplate transactionTemplate;
+
+    @PostConstruct
+    void init() {
+        transactionTemplate = new TransactionTemplate(transactionManager);
+    }
+
+    @KafkaListener(
+            topics = "${app.kafka.topics.transaction-events}",
+            groupId = "payment-processor"
+    )
+    public void onTransactionEvent(TransactionEventMessage message) {
+        if (message.eventType() != TransactionEventType.CREATED) {
+            return;
+        }
+
+        UUID transactionId = message.transactionId();
+        String lockKey = LOCK_PREFIX + transactionId;
+
+        boolean locked = distributedLock.tryLock(lockKey, 0, LOCK_LEASE_SECONDS);
+        if (!locked) {
+            log.warn("Could not acquire processing lock — another instance is handling: transactionId={}", transactionId);
+            return;
+        }
+
+        try {
+            process(transactionId);
+        } catch (OptimisticLockingFailureException e) {
+            log.warn("Optimistic lock conflict — transaction already processed by another instance: transactionId={}", transactionId);
+        } catch (Exception e) {
+            log.error("Unexpected error processing transaction: transactionId={}, error={}", transactionId, e.getMessage(), e);
+            throw e; // propagate so Kafka retries via DefaultErrorHandler
+        } finally {
+            distributedLock.unlock(lockKey);
+        }
+    }
+
+    private void process(UUID transactionId) {
+        // ── Phase 1: PENDING → PROCESSING ────────────────────────────────────
+        Transaction tx = transactionTemplate.execute(status -> {
+            Transaction loaded = transactionRepository.findById(transactionId)
+                    .orElseThrow(() -> new TransactionNotFoundException(transactionId));
+
+            if (loaded.getStatus() != TransactionStatus.PENDING) {
+                log.info("Skipping already-processed transaction: transactionId={}, currentStatus={}",
+                        transactionId, loaded.getStatus());
+                return null;
+            }
+
+            loaded.startProcessing();
+            Transaction saved = transactionRepository.save(loaded);
+            eventPublisher.publish(saved, TransactionEventType.PROCESSING);
+            log.info("Transaction PROCESSING: transactionId={}", transactionId);
+            return saved;
+        });
+
+        if (tx == null) {
+            return; // already past PENDING — idempotent skip
+        }
+
+        // ── Phase 2: Gateway call + finalisation ──────────────────────────────
+        // Runs OUTSIDE any DB transaction — the gateway call is an IO operation
+        // and should not hold a DB connection open for its duration.
+        try {
+            String gatewayRef = paymentGateway.charge(tx.getId(), tx.getAmount());
+            finaliseSuccess(tx.getId(), tx.getToAccountId(), tx.getAmount(), gatewayRef);
+
+        } catch (PaymentGatewayTimeoutException e) {
+            log.warn("Gateway timeout after retries — marking TIMEOUT: transactionId={}", transactionId);
+            finaliseFailure(tx.getId(), tx.getFromAccountId(), tx.getAmount(), TransactionStatus.TIMEOUT,
+                    "Gateway timeout after retries");
+
+        } catch (PaymentGatewayException e) {
+            log.warn("Gateway rejected payment — marking FAILED: transactionId={}, reason={}", transactionId, e.getMessage());
+            finaliseFailure(tx.getId(), tx.getFromAccountId(), tx.getAmount(), TransactionStatus.FAILED,
+                    e.getMessage());
+
+        } catch (CallNotPermittedException e) {
+            log.error("Circuit breaker OPEN — marking FAILED: transactionId={}", transactionId);
+            finaliseFailure(tx.getId(), tx.getFromAccountId(), tx.getAmount(), TransactionStatus.FAILED,
+                    "Payment gateway unavailable (circuit breaker open)");
+        }
+    }
+
+    private void finaliseSuccess(UUID transactionId, UUID toAccountId, BigDecimal amount, String gatewayRef) {
+        transactionTemplate.executeWithoutResult(status -> {
+            Transaction tx = transactionRepository.findById(transactionId).orElseThrow();
+            tx.complete(gatewayRef);
+            transactionRepository.save(tx);
+
+            Account toAccount = accountRepository.findByIdForUpdate(toAccountId).orElseThrow();
+            toAccount.credit(amount);
+            accountRepository.save(toAccount);
+
+            log.info("Transaction SUCCESS: transactionId={}, gatewayRef={}, creditedAccount={}",
+                    transactionId, gatewayRef, toAccountId);
+            eventPublisher.publish(tx, TransactionEventType.SUCCESS);
+        });
+    }
+
+    private void finaliseFailure(UUID transactionId, UUID fromAccountId, BigDecimal amount,
+                                  TransactionStatus finalStatus, String reason) {
+        transactionTemplate.executeWithoutResult(status -> {
+            Transaction tx = transactionRepository.findById(transactionId).orElseThrow();
+
+            if (finalStatus == TransactionStatus.TIMEOUT) {
+                tx.timeout();
+            } else {
+                tx.fail(reason);
+            }
+            transactionRepository.save(tx);
+
+            // Restore sender's balance — funds were held on CREATED
+            Account fromAccount = accountRepository.findByIdForUpdate(fromAccountId).orElseThrow();
+            fromAccount.credit(amount);
+            accountRepository.save(fromAccount);
+
+            log.info("Transaction {}: transactionId={}, reason={}, restoredAccount={}",
+                    finalStatus, transactionId, reason, fromAccountId);
+
+            TransactionEventType eventType = finalStatus == TransactionStatus.TIMEOUT
+                    ? TransactionEventType.TIMEOUT
+                    : TransactionEventType.FAILED;
+            eventPublisher.publish(tx, eventType);
+        });
+    }
+}

--- a/backend/src/main/java/dev/cuong/payment/infrastructure/lock/DistributedLockConfig.java
+++ b/backend/src/main/java/dev/cuong/payment/infrastructure/lock/DistributedLockConfig.java
@@ -1,0 +1,41 @@
+package dev.cuong.payment.infrastructure.lock;
+
+import dev.cuong.payment.application.port.out.DistributedLockPort;
+import lombok.extern.slf4j.Slf4j;
+import org.redisson.api.RedissonClient;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Wires the appropriate {@link DistributedLockPort} depending on Redis availability.
+ *
+ * <p>Uses the same {@link ObjectProvider} pattern as {@code RateLimiterConfig}: resolves
+ * at injection time so the test's {@code @TestConfiguration} Redis bean is visible.
+ * When Redis is absent, a no-op lock (always acquires) is used — the JPA optimistic lock
+ * on the transaction entity acts as the safety net against double-processing.
+ */
+@Configuration
+@Slf4j
+public class DistributedLockConfig {
+
+    @Bean
+    public DistributedLockPort distributedLockPort(ObjectProvider<RedissonClient> redissonProvider) {
+        RedissonClient client = redissonProvider.getIfAvailable();
+        if (client != null) {
+            log.info("Distributed lock: Redis (Redisson)");
+            return new RedisDistributedLock(client);
+        }
+        log.warn("Distributed lock: no-op (Redis unavailable — optimistic lock is the only guard)");
+        return new DistributedLockPort() {
+            @Override
+            public boolean tryLock(String key, long waitSeconds, long leaseSeconds) {
+                return true;
+            }
+
+            @Override
+            public void unlock(String key) {
+            }
+        };
+    }
+}

--- a/backend/src/main/java/dev/cuong/payment/infrastructure/lock/RedisDistributedLock.java
+++ b/backend/src/main/java/dev/cuong/payment/infrastructure/lock/RedisDistributedLock.java
@@ -1,0 +1,57 @@
+package dev.cuong.payment.infrastructure.lock;
+
+import dev.cuong.payment.application.port.out.DistributedLockPort;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Redis-backed distributed lock using Redisson's {@link RLock}.
+ *
+ * <p>Not annotated with {@code @Component} — created by {@link DistributedLockConfig}
+ * via {@code ObjectProvider<RedissonClient>} so that a no-op fallback can be provided
+ * when Redis is unavailable (same pattern as {@code RateLimiterConfig}).
+ *
+ * <p>The {@code leaseSeconds} parameter is critical: if the holding process crashes before
+ * calling {@link #unlock}, Redis automatically releases the lock after the lease expires,
+ * preventing deadlock. Set it to slightly longer than the maximum expected processing time.
+ */
+@Slf4j
+@RequiredArgsConstructor
+public class RedisDistributedLock implements DistributedLockPort {
+
+    private final RedissonClient redissonClient;
+
+    @Override
+    public boolean tryLock(String key, long waitSeconds, long leaseSeconds) {
+        try {
+            RLock lock = redissonClient.getLock(key);
+            boolean acquired = lock.tryLock(waitSeconds, leaseSeconds, TimeUnit.SECONDS);
+            if (!acquired) {
+                log.debug("Lock not acquired: key={}", key);
+            }
+            return acquired;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            log.warn("Interrupted while acquiring lock: key={}", key);
+            return false;
+        }
+    }
+
+    @Override
+    public void unlock(String key) {
+        try {
+            RLock lock = redissonClient.getLock(key);
+            // isHeldByCurrentThread() prevents IllegalMonitorStateException when the
+            // lease has already expired or the lock was never acquired by this thread.
+            if (lock.isHeldByCurrentThread()) {
+                lock.unlock();
+            }
+        } catch (Exception e) {
+            log.warn("Failed to release lock: key={}, error={}", key, e.getMessage());
+        }
+    }
+}

--- a/backend/src/main/java/dev/cuong/payment/infrastructure/persistence/adapter/AccountRepositoryAdapter.java
+++ b/backend/src/main/java/dev/cuong/payment/infrastructure/persistence/adapter/AccountRepositoryAdapter.java
@@ -32,6 +32,11 @@ public class AccountRepositoryAdapter implements AccountRepository {
     }
 
     @Override
+    public Optional<Account> findByIdForUpdate(UUID accountId) {
+        return jpaRepository.findByIdWithLock(accountId).map(AccountMapper::toDomain);
+    }
+
+    @Override
     public Account save(Account account) {
         return AccountMapper.toDomain(jpaRepository.save(AccountMapper.toEntity(account)));
     }

--- a/backend/src/main/java/dev/cuong/payment/infrastructure/persistence/repository/AccountJpaRepository.java
+++ b/backend/src/main/java/dev/cuong/payment/infrastructure/persistence/repository/AccountJpaRepository.java
@@ -14,9 +14,12 @@ public interface AccountJpaRepository extends JpaRepository<AccountJpaEntity, UU
 
     Optional<AccountJpaEntity> findByUserId(UUID userId);
 
-    // PESSIMISTIC_WRITE → SELECT ... FOR UPDATE. Must be called within
-    // an active @Transactional boundary or PostgreSQL will reject the lock mode.
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT a FROM AccountJpaEntity a WHERE a.userId = :userId")
     Optional<AccountJpaEntity> findByUserIdWithLock(@Param("userId") UUID userId);
+
+    // Consumer uses accountId (from event message), not userId (from JWT).
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT a FROM AccountJpaEntity a WHERE a.id = :id")
+    Optional<AccountJpaEntity> findByIdWithLock(@Param("id") UUID id);
 }

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -124,8 +124,10 @@ resilience4j:
         max-attempts: 3
         wait-duration: 1s
         exponential-backoff-multiplier: 2.0   # 1s → 2s → 4s
-        # retry-exceptions and ignore-exceptions reference gateway exception classes
-        # created in Task 12 — wired in at that point
+        retry-exceptions:
+          - dev.cuong.payment.domain.exception.PaymentGatewayTimeoutException
+        ignore-exceptions:
+          - dev.cuong.payment.domain.exception.PaymentGatewayException
 
 # ── Logging ─────────────────────────────────────────────────────────────────────
 logging:

--- a/backend/src/test/java/dev/cuong/payment/infrastructure/gateway/MockPaymentGatewayTest.java
+++ b/backend/src/test/java/dev/cuong/payment/infrastructure/gateway/MockPaymentGatewayTest.java
@@ -1,0 +1,137 @@
+package dev.cuong.payment.infrastructure.gateway;
+
+import dev.cuong.payment.domain.exception.PaymentGatewayException;
+import dev.cuong.payment.domain.exception.PaymentGatewayTimeoutException;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Unit tests for {@link MockPaymentGateway}.
+ *
+ * <p>Tested without Spring context — {@code @CircuitBreaker} and {@code @Retry} AOP aspects
+ * are inactive here. Each test configures a deterministic {@link GatewayProperties} so that
+ * the probability-based outcome is fully controlled.
+ */
+class MockPaymentGatewayTest {
+
+    private static GatewayProperties propsFor(double success, double fail, double timeout) {
+        GatewayProperties p = new GatewayProperties();
+        p.setSuccessRate(success);
+        p.setFailRate(fail);
+        p.setTimeoutRate(timeout);
+        p.setMinDelayMs(0);
+        p.setMaxDelayMs(0);
+        return p;
+    }
+
+    // ── Deterministic outcomes ────────────────────────────────────────────────
+
+    @Test
+    void should_return_gateway_reference_when_success_rate_is_1() throws Exception {
+        MockPaymentGateway gateway = new MockPaymentGateway(propsFor(1.0, 0.0, 0.0));
+
+        String ref = gateway.charge(UUID.randomUUID(), new BigDecimal("100.00"));
+
+        assertThat(ref).startsWith("GW-");
+        assertThat(ref).hasSize(13); // "GW-" + 10 hex chars
+    }
+
+    @Test
+    void should_throw_gateway_exception_when_fail_rate_is_1() {
+        MockPaymentGateway gateway = new MockPaymentGateway(propsFor(0.0, 1.0, 0.0));
+
+        assertThatThrownBy(() -> gateway.charge(UUID.randomUUID(), BigDecimal.TEN))
+                .isInstanceOf(PaymentGatewayException.class);
+    }
+
+    @Test
+    void should_throw_timeout_exception_when_timeout_rate_is_1() {
+        MockPaymentGateway gateway = new MockPaymentGateway(propsFor(0.0, 0.0, 1.0));
+
+        assertThatThrownBy(() -> gateway.charge(UUID.randomUUID(), BigDecimal.TEN))
+                .isInstanceOf(PaymentGatewayTimeoutException.class);
+    }
+
+    // ── Gateway reference format ──────────────────────────────────────────────
+
+    @Test
+    void should_generate_unique_reference_per_successful_charge() throws Exception {
+        MockPaymentGateway gateway = new MockPaymentGateway(propsFor(1.0, 0.0, 0.0));
+
+        String ref1 = gateway.charge(UUID.randomUUID(), BigDecimal.TEN);
+        String ref2 = gateway.charge(UUID.randomUUID(), BigDecimal.TEN);
+
+        assertThat(ref1).isNotEqualTo(ref2);
+    }
+
+    // ── Probability distribution ──────────────────────────────────────────────
+
+    @Test
+    void should_produce_expected_outcome_distribution_over_many_calls() {
+        MockPaymentGateway gateway = new MockPaymentGateway(propsFor(0.7, 0.2, 0.1));
+
+        int successes = 0;
+        int failures  = 0;
+        int timeouts  = 0;
+        int total = 10_000;
+
+        for (int i = 0; i < total; i++) {
+            try {
+                gateway.charge(UUID.randomUUID(), BigDecimal.TEN);
+                successes++;
+            } catch (PaymentGatewayException e) {
+                failures++;
+            } catch (PaymentGatewayTimeoutException e) {
+                timeouts++;
+            }
+        }
+
+        // Allow ±5% tolerance around configured rates
+        double successPct = (double) successes / total;
+        double failPct    = (double) failures  / total;
+        double timeoutPct = (double) timeouts  / total;
+
+        assertThat(successPct).isBetween(0.65, 0.75);
+        assertThat(failPct)   .isBetween(0.15, 0.25);
+        assertThat(timeoutPct).isBetween(0.05, 0.15);
+    }
+
+    // ── No latency when min/max delay are zero ────────────────────────────────
+
+    @Test
+    void should_complete_without_delay_when_min_and_max_delay_are_zero() throws Exception {
+        MockPaymentGateway gateway = new MockPaymentGateway(propsFor(1.0, 0.0, 0.0));
+
+        long start = System.currentTimeMillis();
+        gateway.charge(UUID.randomUUID(), BigDecimal.TEN);
+        long elapsed = System.currentTimeMillis() - start;
+
+        assertThat(elapsed).isLessThan(500);
+    }
+
+    // ── Multiple amounts handled ──────────────────────────────────────────────
+
+    @Test
+    void should_accept_varying_amounts() {
+        MockPaymentGateway gateway = new MockPaymentGateway(propsFor(1.0, 0.0, 0.0));
+        List<BigDecimal> amounts = List.of(
+                new BigDecimal("0.01"),
+                new BigDecimal("999999.99"),
+                new BigDecimal("100.00")
+        );
+
+        amounts.forEach(amount -> {
+            try {
+                assertThat(gateway.charge(UUID.randomUUID(), amount)).isNotBlank();
+            } catch (Exception e) {
+                throw new AssertionError("Unexpected exception for amount " + amount, e);
+            }
+        });
+    }
+}

--- a/backend/src/test/java/dev/cuong/payment/infrastructure/kafka/TransactionProcessingConsumerIntegrationTest.java
+++ b/backend/src/test/java/dev/cuong/payment/infrastructure/kafka/TransactionProcessingConsumerIntegrationTest.java
@@ -1,0 +1,330 @@
+package dev.cuong.payment.infrastructure.kafka;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.cuong.payment.application.port.out.AccountRepository;
+import dev.cuong.payment.application.port.out.EventPublisher;
+import dev.cuong.payment.application.port.out.PaymentGatewayPort;
+import dev.cuong.payment.application.port.out.TransactionRepository;
+import dev.cuong.payment.domain.event.TransactionEventType;
+import dev.cuong.payment.domain.exception.PaymentGatewayException;
+import dev.cuong.payment.domain.exception.PaymentGatewayTimeoutException;
+import dev.cuong.payment.domain.model.Account;
+import dev.cuong.payment.domain.model.Transaction;
+import dev.cuong.payment.domain.vo.TransactionStatus;
+import dev.cuong.payment.presentation.auth.RegisterRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * End-to-end integration test for {@link TransactionProcessingConsumer}.
+ *
+ * <p>Uses real Postgres, Kafka, and Redis containers. {@link PaymentGatewayPort} is replaced
+ * by a stub controlled via {@link #gatewayMode} so each test scenario is deterministic.
+ *
+ * <p>Tests are NOT {@code @Transactional}: the Kafka consumer runs in its own thread and
+ * transaction; an outer rollback-only test transaction would hide committed data from it.
+ * Each test uses unique usernames to avoid state conflicts within the shared static containers.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@Testcontainers
+@TestPropertySource(properties = {
+        // Exclude Redisson auto-config — replaced by TestRedissonConfig below
+        "spring.autoconfigure.exclude=org.redisson.spring.starter.RedissonAutoConfigurationV2",
+        "spring.flyway.enabled=true",
+        "spring.flyway.validate-on-migrate=true",
+        "spring.jpa.hibernate.ddl-auto=validate",
+        "app.jwt.secret=test-secret-key-minimum-32-chars-for-hs256!",
+        // High limit so tests don't hit the rate limiter
+        "app.rate-limit.max-requests-per-minute=1000",
+        // Keep circuit breaker inactive — stub gateway is deterministic, no need for resilience4j state
+        "resilience4j.circuitbreaker.instances.payment-gateway.sliding-window-size=1000",
+        "resilience4j.circuitbreaker.instances.payment-gateway.minimum-number-of-calls=1000"
+})
+class TransactionProcessingConsumerIntegrationTest {
+
+    static final KafkaContainer kafka =
+            new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.6.1"));
+
+    static final PostgreSQLContainer<?> postgres =
+            new PostgreSQLContainer<>("postgres:15-alpine");
+
+    @SuppressWarnings("resource")
+    static final GenericContainer<?> redis =
+            new GenericContainer<>("redis:7-alpine").withExposedPorts(6379);
+
+    static {
+        kafka.start();
+        postgres.start();
+        redis.start();
+    }
+
+    @DynamicPropertySource
+    static void overrideProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.kafka.bootstrap-servers", kafka::getBootstrapServers);
+        registry.add("spring.datasource.url", postgres::getJdbcUrl);
+        registry.add("spring.datasource.username", postgres::getUsername);
+        registry.add("spring.datasource.password", postgres::getPassword);
+        registry.add("spring.data.redis.host", redis::getHost);
+        registry.add("spring.data.redis.port", () -> redis.getMappedPort(6379));
+    }
+
+    // ── Gateway stub + Redis wiring ───────────────────────────────────────────
+
+    enum GatewayMode { SUCCESS, FAIL, TIMEOUT }
+
+    static final AtomicReference<GatewayMode> gatewayMode =
+            new AtomicReference<>(GatewayMode.SUCCESS);
+
+    @TestConfiguration
+    static class StubConfig {
+
+        @Bean
+        @Primary
+        RedissonClient testRedissonClient() {
+            Config config = new Config();
+            config.useSingleServer()
+                    .setAddress("redis://" + redis.getHost() + ":" + redis.getMappedPort(6379))
+                    .setConnectionPoolSize(4)
+                    .setConnectionMinimumIdleSize(1);
+            return Redisson.create(config);
+        }
+
+        // Overrides MockPaymentGateway — gives tests full control over gateway outcomes
+        // without the non-determinism of random rolls or the delay of Resilience4j retries.
+        @Bean
+        @Primary
+        PaymentGatewayPort stubPaymentGateway() {
+            return (txId, amount) -> switch (gatewayMode.get()) {
+                case SUCCESS -> "GW-STUB-" + txId.toString().replace("-", "").substring(0, 8).toUpperCase();
+                case FAIL -> throw new PaymentGatewayException("Stubbed rejection");
+                case TIMEOUT -> throw new PaymentGatewayTimeoutException("Stubbed timeout");
+            };
+        }
+    }
+
+    @Autowired MockMvc mockMvc;
+    @Autowired ObjectMapper objectMapper;
+    @Autowired TransactionRepository transactionRepository;
+    @Autowired AccountRepository accountRepository;
+    @Autowired EventPublisher eventPublisher;
+
+    @BeforeEach
+    void resetGateway() {
+        gatewayMode.set(GatewayMode.SUCCESS);
+    }
+
+    // ── SUCCESS: gateway accepts ──────────────────────────────────────────────
+
+    @Test
+    void should_credit_receiver_and_mark_success_when_gateway_accepts() throws Exception {
+        String senderToken   = registerAndGetToken("cpc-alice", "cpc-alice@test.com");
+        String receiverToken = registerAndGetToken("cpc-bob",   "cpc-bob@test.com");
+
+        UUID senderUserId   = extractUserId(senderToken);
+        UUID receiverUserId = extractUserId(receiverToken);
+        UUID toAccountId    = accountRepository.findByUserId(receiverUserId).orElseThrow().getId();
+
+        fundAccount(senderUserId, new BigDecimal("500.00"));
+
+        UUID txId = createTransaction(senderToken, toAccountId, "200.00", "Success test");
+
+        await().atMost(10, SECONDS).untilAsserted(() ->
+                assertThat(transactionRepository.findById(txId).orElseThrow().getStatus())
+                        .isEqualTo(TransactionStatus.SUCCESS));
+
+        Transaction tx = transactionRepository.findById(txId).orElseThrow();
+        assertThat(tx.getGatewayReference()).isNotBlank();
+
+        // Receiver credited on SUCCESS
+        Account receiver = accountRepository.findByUserId(receiverUserId).orElseThrow();
+        assertThat(receiver.getBalance()).isEqualByComparingTo("200.00");
+
+        // Sender: 500 initial − 200 debit on CREATED = 300; SUCCESS does NOT restore sender
+        Account sender = accountRepository.findByUserId(senderUserId).orElseThrow();
+        assertThat(sender.getBalance()).isEqualByComparingTo("300.00");
+    }
+
+    // ── FAILED: gateway permanently rejects ──────────────────────────────────
+
+    @Test
+    void should_restore_sender_and_mark_failed_when_gateway_rejects() throws Exception {
+        gatewayMode.set(GatewayMode.FAIL);
+
+        String senderToken   = registerAndGetToken("cpc-carol", "cpc-carol@test.com");
+        String receiverToken = registerAndGetToken("cpc-dave",  "cpc-dave@test.com");
+
+        UUID senderUserId   = extractUserId(senderToken);
+        UUID receiverUserId = extractUserId(receiverToken);
+        UUID toAccountId    = accountRepository.findByUserId(receiverUserId).orElseThrow().getId();
+
+        fundAccount(senderUserId, new BigDecimal("500.00"));
+
+        UUID txId = createTransaction(senderToken, toAccountId, "200.00", "Fail test");
+
+        await().atMost(10, SECONDS).untilAsserted(() ->
+                assertThat(transactionRepository.findById(txId).orElseThrow().getStatus())
+                        .isEqualTo(TransactionStatus.FAILED));
+
+        Transaction tx = transactionRepository.findById(txId).orElseThrow();
+        assertThat(tx.getFailureReason()).isNotBlank();
+
+        // Sender restored: 500 − 200 (debit on CREATED) + 200 (restore on FAILED) = 500
+        Account sender = accountRepository.findByUserId(senderUserId).orElseThrow();
+        assertThat(sender.getBalance()).isEqualByComparingTo("500.00");
+
+        // Receiver never credited
+        Account receiver = accountRepository.findByUserId(receiverUserId).orElseThrow();
+        assertThat(receiver.getBalance()).isEqualByComparingTo("0.00");
+    }
+
+    // ── TIMEOUT: gateway times out ────────────────────────────────────────────
+
+    @Test
+    void should_restore_sender_and_mark_timeout_when_gateway_times_out() throws Exception {
+        gatewayMode.set(GatewayMode.TIMEOUT);
+
+        String senderToken   = registerAndGetToken("cpc-eve",  "cpc-eve@test.com");
+        String receiverToken = registerAndGetToken("cpc-frank", "cpc-frank@test.com");
+
+        UUID senderUserId   = extractUserId(senderToken);
+        UUID receiverUserId = extractUserId(receiverToken);
+        UUID toAccountId    = accountRepository.findByUserId(receiverUserId).orElseThrow().getId();
+
+        fundAccount(senderUserId, new BigDecimal("300.00"));
+
+        UUID txId = createTransaction(senderToken, toAccountId, "150.00", "Timeout test");
+
+        await().atMost(10, SECONDS).untilAsserted(() ->
+                assertThat(transactionRepository.findById(txId).orElseThrow().getStatus())
+                        .isEqualTo(TransactionStatus.TIMEOUT));
+
+        // Sender restored: 300 − 150 + 150 = 300
+        Account sender = accountRepository.findByUserId(senderUserId).orElseThrow();
+        assertThat(sender.getBalance()).isEqualByComparingTo("300.00");
+
+        Account receiver = accountRepository.findByUserId(receiverUserId).orElseThrow();
+        assertThat(receiver.getBalance()).isEqualByComparingTo("0.00");
+    }
+
+    // ── Idempotency: duplicate CREATED event is a no-op ──────────────────────
+
+    @Test
+    void should_not_reprocess_when_duplicate_created_event_arrives_after_success() throws Exception {
+        String senderToken   = registerAndGetToken("cpc-george", "cpc-george@test.com");
+        String receiverToken = registerAndGetToken("cpc-helen",  "cpc-helen@test.com");
+
+        UUID senderUserId   = extractUserId(senderToken);
+        UUID receiverUserId = extractUserId(receiverToken);
+        UUID toAccountId    = accountRepository.findByUserId(receiverUserId).orElseThrow().getId();
+
+        fundAccount(senderUserId, new BigDecimal("500.00"));
+
+        // Initial creation → CREATED event published → consumer processes → SUCCESS
+        UUID txId = createTransaction(senderToken, toAccountId, "100.00", "Idempotency test");
+
+        await().atMost(10, SECONDS).untilAsserted(() ->
+                assertThat(transactionRepository.findById(txId).orElseThrow().getStatus())
+                        .isEqualTo(TransactionStatus.SUCCESS));
+
+        // Receiver credited exactly once so far
+        assertThat(accountRepository.findByUserId(receiverUserId).orElseThrow().getBalance())
+                .isEqualByComparingTo("100.00");
+
+        // Simulate Kafka re-delivery: publish a duplicate CREATED for the already-SUCCESS transaction.
+        // Switch to FAIL mode — if the consumer naively re-processes, it would mark the tx FAILED.
+        gatewayMode.set(GatewayMode.FAIL);
+        Transaction successTx = transactionRepository.findById(txId).orElseThrow();
+        eventPublisher.publish(successTx, TransactionEventType.CREATED);
+
+        // Give the consumer enough time to pick up and (incorrectly) reprocess — if it did,
+        // status would change to FAILED within a few seconds.
+        Thread.sleep(3000);
+
+        // Status must still be SUCCESS — the consumer's Phase 1 detects non-PENDING and skips
+        assertThat(transactionRepository.findById(txId).orElseThrow().getStatus())
+                .isEqualTo(TransactionStatus.SUCCESS);
+
+        // Receiver balance unchanged — no double-credit
+        assertThat(accountRepository.findByUserId(receiverUserId).orElseThrow().getBalance())
+                .isEqualByComparingTo("100.00");
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private String registerAndGetToken(String username, String email) throws Exception {
+        MvcResult result = mockMvc.perform(post("/api/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                new RegisterRequest(username, email, "password123"))))
+                .andExpect(status().isCreated())
+                .andReturn();
+        return objectMapper.readTree(result.getResponse().getContentAsString()).get("token").asText();
+    }
+
+    private UUID extractUserId(String token) throws Exception {
+        MvcResult result = mockMvc.perform(get("/api/users/me")
+                        .header("Authorization", "Bearer " + token))
+                .andReturn();
+        return UUID.fromString(
+                objectMapper.readTree(result.getResponse().getContentAsString()).get("id").asText());
+    }
+
+    private void fundAccount(UUID userId, BigDecimal amount) {
+        Account account = accountRepository.findByUserId(userId).orElseThrow();
+        account.credit(amount);
+        accountRepository.save(account);
+    }
+
+    private UUID createTransaction(String token, UUID toAccountId, String amount, String description)
+            throws Exception {
+        MvcResult result = mockMvc.perform(post("/api/transactions")
+                        .header("Authorization", "Bearer " + token)
+                        .header("Idempotency-Key", UUID.randomUUID().toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(txBody(toAccountId, amount, description)))
+                .andExpect(status().isCreated())
+                .andReturn();
+        return UUID.fromString(
+                objectMapper.readTree(result.getResponse().getContentAsString()).get("id").asText());
+    }
+
+    private String txBody(UUID toAccountId, String amount, String description) throws Exception {
+        var node = objectMapper.createObjectNode();
+        node.put("toAccountId", toAccountId.toString());
+        node.put("amount", new BigDecimal(amount));
+        if (description != null) node.put("description", description);
+        return objectMapper.writeValueAsString(node);
+    }
+}


### PR DESCRIPTION
## What this PR does
Closes #14 

Implements the async transaction processing pipeline. A Kafka consumer
(`payment-processor` group) picks up CREATED events and drives each transaction
through the state machine: acquires a Redis distributed lock, transitions
PENDING → PROCESSING inside a short DB transaction, calls the simulated payment
gateway (protected by Resilience4j circuit breaker + retry), then finalises to
SUCCESS/FAILED/TIMEOUT in a second short DB transaction that also updates account
balances. On FAILED or TIMEOUT, the sender's held funds are returned immediately.

## How to test

1. Start infrastructure: `docker-compose up -d`
2. Run unit tests: `./gradlew test --tests "*.MockPaymentGatewayTest"`
3. Run integration tests:
   `./gradlew test --tests "*.TransactionProcessingConsumerIntegrationTest"`
4. Manual smoke test:
   - Register two users via `POST /api/auth/register`
   - Fund sender via `POST /api/accounts/me/deposit`
   - Create a transaction via `POST /api/transactions`
   - Poll `GET /api/transactions/{id}` - status moves PENDING → PROCESSING → SUCCESS
   - Verify receiver balance increased and sender balance decreased by the amount

## Technical decisions

**Two-phase TransactionTemplate instead of a single @Transactional method:**
Holding a DB connection open during a network call to the payment gateway would
exhaust the HikariCP pool under load. Phase 1 commits the PROCESSING state
immediately; Phase 2 commits the terminal state + balance updates after the
gateway returns. The distributed Redis lock guards the gap between the two
transactions; the JPA @Version optimistic lock is the fallback if the Redis lease
expires mid-flight.

**No-op DistributedLockPort fallback via ObjectProvider:**
Same pattern used by RateLimiterConfig - resolves at injection time so test
@TestConfiguration beans are visible, and gracefully degrades to always-acquire
when Redis is absent. The optimistic lock alone is sufficient safety for
single-instance or test environments.

**Stub gateway with @TestConfiguration @Primary over Mockito:**
The project rule is integration tests with real infrastructure, no mocks. The stub
implements the same port interface, is wired via @Primary, and is controlled
through a static AtomicReference - giving full determinism without mocking
frameworks and keeping the Kafka + Postgres + Redis round-trip fully exercised.