### PR TITLE
Task/13 notification audit consumers

### DIFF
--- a/backend/src/main/java/dev/cuong/payment/application/port/out/AuditRepository.java
+++ b/backend/src/main/java/dev/cuong/payment/application/port/out/AuditRepository.java
@@ -1,0 +1,38 @@
+package dev.cuong.payment.application.port.out;
+
+import java.util.UUID;
+
+/**
+ * Output port for persisting immutable audit log entries.
+ *
+ * <p>Audit records must never be updated or deleted — each call to {@link #record}
+ * produces a new, append-only row. Implementations must be {@code @Transactional}
+ * so that a DB failure rolls back the write and allows the Kafka consumer to retry.
+ */
+public interface AuditRepository {
+
+    /**
+     * Persists a single audit entry to the append-only audit log.
+     *
+     * @param entry the audit record to persist — immutable after creation
+     */
+    void record(AuditEntry entry);
+
+    /**
+     * Payload passed from the Kafka consumer layer to the persistence adapter.
+     *
+     * @param transactionId the transaction this event belongs to (nullable for
+     *                      user-scoped events such as login)
+     * @param userId        the user who owns the {@code fromAccount}
+     * @param eventType     string representation of {@link dev.cuong.payment.domain.event.TransactionEventType}
+     * @param newStatus     the transaction status after this event
+     * @param metadata      JSON-encoded supplemental fields (amount, accounts, gateway ref, etc.)
+     */
+    record AuditEntry(
+            UUID transactionId,
+            UUID userId,
+            String eventType,
+            String newStatus,
+            String metadata
+    ) {}
+}

--- a/backend/src/main/java/dev/cuong/payment/infrastructure/kafka/AuditConsumer.java
+++ b/backend/src/main/java/dev/cuong/payment/infrastructure/kafka/AuditConsumer.java
@@ -1,0 +1,102 @@
+package dev.cuong.payment.infrastructure.kafka;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.cuong.payment.application.port.out.AccountRepository;
+import dev.cuong.payment.application.port.out.AuditRepository;
+import dev.cuong.payment.domain.model.Account;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Kafka consumer that persists an immutable audit entry for every transaction
+ * lifecycle event.
+ *
+ * <p><strong>Critical consumer:</strong> unlike the notification consumer, this consumer
+ * re-throws all exceptions so the Kafka listener withholds the offset commit. The broker
+ * re-delivers the message and {@link org.springframework.kafka.listener.DefaultErrorHandler}
+ * retries up to the configured limit before routing to the DLQ (Task 15).
+ *
+ * <p><strong>Transaction semantics:</strong> {@code @Transactional} on the listener method
+ * means the DB INSERT and the Kafka offset commit succeed or fail together — if the INSERT
+ * fails the transaction rolls back, the offset is not committed, and Kafka retries.
+ *
+ * <p><strong>userId resolution:</strong> {@code TransactionEventMessage} carries
+ * {@code fromAccountId} but not {@code userId}. The consumer loads the account from the DB
+ * to obtain the owner's {@code userId}. Since {@code audit_logs.user_id} is {@code NOT NULL},
+ * the account ID itself is used as a fallback if the account is unexpectedly absent.
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class AuditConsumer {
+
+    private final AuditRepository auditRepository;
+    private final AccountRepository accountRepository;
+    private final ObjectMapper objectMapper;
+
+    @KafkaListener(
+            topics = "${app.kafka.topics.transaction-events}",
+            groupId = "audit"
+    )
+    @Transactional
+    public void onTransactionEvent(TransactionEventMessage event) {
+        try {
+            UUID userId = resolveUserId(event);
+            String metadata = buildMetadata(event);
+
+            auditRepository.record(new AuditRepository.AuditEntry(
+                    event.transactionId(),
+                    userId,
+                    event.eventType().name(),
+                    event.status(),
+                    metadata
+            ));
+
+            log.info("[AUDIT] Recorded: transactionId={}, eventType={}, userId={}",
+                    event.transactionId(), event.eventType(), userId);
+
+        } catch (Exception e) {
+            log.error("[AUDIT] Failed to record event — will retry: transactionId={}, eventType={}, error={}",
+                    event.transactionId(), event.eventType(), e.getMessage(), e);
+            throw e;
+        }
+    }
+
+    private UUID resolveUserId(TransactionEventMessage event) {
+        return accountRepository.findById(event.fromAccountId())
+                .map(Account::getUserId)
+                .orElseGet(() -> {
+                    log.warn("[AUDIT] Account not found for fromAccountId={} — using accountId as userId proxy",
+                            event.fromAccountId());
+                    return event.fromAccountId();
+                });
+    }
+
+    private String buildMetadata(TransactionEventMessage event) {
+        Map<String, Object> meta = new LinkedHashMap<>();
+        meta.put("amount", event.amount());
+        meta.put("currency", event.currency());
+        meta.put("fromAccountId", event.fromAccountId());
+        meta.put("toAccountId", event.toAccountId());
+        if (event.description() != null)        meta.put("description", event.description());
+        if (event.gatewayReference() != null)   meta.put("gatewayReference", event.gatewayReference());
+        if (event.failureReason() != null)      meta.put("failureReason", event.failureReason());
+        meta.put("retryCount", event.retryCount());
+
+        try {
+            return objectMapper.writeValueAsString(meta);
+        } catch (JsonProcessingException e) {
+            log.warn("[AUDIT] Could not serialize metadata for transactionId={} — storing empty object",
+                    event.transactionId());
+            return "{}";
+        }
+    }
+}

--- a/backend/src/main/java/dev/cuong/payment/infrastructure/kafka/NotificationConsumer.java
+++ b/backend/src/main/java/dev/cuong/payment/infrastructure/kafka/NotificationConsumer.java
@@ -1,0 +1,79 @@
+package dev.cuong.payment.infrastructure.kafka;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+/**
+ * Kafka consumer that dispatches simulated notifications (email / SMS) for every
+ * transaction lifecycle event.
+ *
+ * <p>Consumer group {@code notification} maintains its own independent offset from
+ * {@code payment-processor} — every message on {@code payment.transaction.events} is
+ * delivered to both groups regardless of the other group's lag or state.
+ *
+ * <p>In production this class would delegate to a {@code NotificationPort} output port
+ * (e.g. an email/SMS gateway). For the portfolio implementation, structured log statements
+ * simulate the dispatched notifications without making real external calls.
+ */
+@Component
+@Slf4j
+public class NotificationConsumer {
+
+    @KafkaListener(
+            topics = "${app.kafka.topics.transaction-events}",
+            groupId = "notification"
+    )
+    public void onTransactionEvent(TransactionEventMessage event) {
+        switch (event.eventType()) {
+            case CREATED    -> notifyInitiated(event);
+            case PROCESSING -> notifyProcessing(event);
+            case SUCCESS    -> notifySucceeded(event);
+            case FAILED     -> notifyFailed(event);
+            case TIMEOUT    -> notifyTimedOut(event);
+            case REFUNDED   -> notifyRefunded(event);
+        }
+    }
+
+    private void notifyInitiated(TransactionEventMessage e) {
+        log.info("[NOTIFY] email→sender: Payment of {} {} initiated — awaiting processing. " +
+                        "transactionId={}, toAccount={}",
+                e.amount(), e.currency(), e.transactionId(), e.toAccountId());
+    }
+
+    private void notifyProcessing(TransactionEventMessage e) {
+        log.info("[NOTIFY] email→sender: Your payment is being processed by the gateway. " +
+                        "transactionId={}",
+                e.transactionId());
+    }
+
+    private void notifySucceeded(TransactionEventMessage e) {
+        log.info("[NOTIFY] email→sender: Payment of {} {} completed successfully. " +
+                        "email→receiver: {} {} has been deposited to your account. " +
+                        "transactionId={}, gatewayRef={}",
+                e.amount(), e.currency(),
+                e.amount(), e.currency(),
+                e.transactionId(), e.gatewayReference());
+    }
+
+    private void notifyFailed(TransactionEventMessage e) {
+        log.info("[NOTIFY] email→sender: Payment of {} {} could not be processed — " +
+                        "your funds have been returned. transactionId={}, reason={}",
+                e.amount(), e.currency(), e.transactionId(), e.failureReason());
+    }
+
+    private void notifyTimedOut(TransactionEventMessage e) {
+        log.info("[NOTIFY] email→sender: Payment of {} {} timed out — " +
+                        "your funds have been returned. transactionId={}",
+                e.amount(), e.currency(), e.transactionId());
+    }
+
+    private void notifyRefunded(TransactionEventMessage e) {
+        log.info("[NOTIFY] email→sender: Refund of {} {} has been processed. " +
+                        "email→receiver: {} {} has been deducted following a refund. " +
+                        "transactionId={}",
+                e.amount(), e.currency(),
+                e.amount(), e.currency(),
+                e.transactionId());
+    }
+}

--- a/backend/src/main/java/dev/cuong/payment/infrastructure/persistence/adapter/AuditRepositoryAdapter.java
+++ b/backend/src/main/java/dev/cuong/payment/infrastructure/persistence/adapter/AuditRepositoryAdapter.java
@@ -1,0 +1,26 @@
+package dev.cuong.payment.infrastructure.persistence.adapter;
+
+import dev.cuong.payment.application.port.out.AuditRepository;
+import dev.cuong.payment.infrastructure.persistence.entity.AuditLogJpaEntity;
+import dev.cuong.payment.infrastructure.persistence.repository.AuditLogJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class AuditRepositoryAdapter implements AuditRepository {
+
+    private final AuditLogJpaRepository jpaRepository;
+
+    @Override
+    public void record(AuditEntry entry) {
+        AuditLogJpaEntity entity = AuditLogJpaEntity.builder()
+                .transactionId(entry.transactionId())
+                .userId(entry.userId())
+                .eventType(entry.eventType())
+                .newStatus(entry.newStatus())
+                .metadata(entry.metadata())
+                .build();
+        jpaRepository.save(entity);
+    }
+}

--- a/backend/src/main/java/dev/cuong/payment/infrastructure/persistence/entity/AuditLogJpaEntity.java
+++ b/backend/src/main/java/dev/cuong/payment/infrastructure/persistence/entity/AuditLogJpaEntity.java
@@ -1,0 +1,52 @@
+package dev.cuong.payment.infrastructure.persistence.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Entity
+@Table(name = "audit_logs")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class AuditLogJpaEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    // Nullable: some audit events are user-scoped (login) rather than transaction-scoped.
+    @Column(name = "transaction_id")
+    private UUID transactionId;
+
+    @Column(name = "user_id", nullable = false)
+    private UUID userId;
+
+    @Column(name = "event_type", nullable = false, length = 50)
+    private String eventType;
+
+    @Column(name = "old_status", length = 20)
+    private String oldStatus;
+
+    @Column(name = "new_status", length = 20)
+    private String newStatus;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(columnDefinition = "jsonb")
+    private String metadata;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @PrePersist
+    void prePersist() {
+        if (createdAt == null) {
+            createdAt = Instant.now();
+        }
+    }
+}

--- a/backend/src/main/java/dev/cuong/payment/infrastructure/persistence/repository/AuditLogJpaRepository.java
+++ b/backend/src/main/java/dev/cuong/payment/infrastructure/persistence/repository/AuditLogJpaRepository.java
@@ -1,0 +1,14 @@
+package dev.cuong.payment.infrastructure.persistence.repository;
+
+import dev.cuong.payment.infrastructure.persistence.entity.AuditLogJpaEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface AuditLogJpaRepository extends JpaRepository<AuditLogJpaEntity, UUID> {
+
+    List<AuditLogJpaEntity> findByTransactionIdOrderByCreatedAtAsc(UUID transactionId);
+
+    long countByTransactionId(UUID transactionId);
+}

--- a/backend/src/test/java/dev/cuong/payment/infrastructure/kafka/AuditConsumerIntegrationTest.java
+++ b/backend/src/test/java/dev/cuong/payment/infrastructure/kafka/AuditConsumerIntegrationTest.java
@@ -1,0 +1,227 @@
+package dev.cuong.payment.infrastructure.kafka;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.cuong.payment.application.port.out.AccountRepository;
+import dev.cuong.payment.application.port.out.EventPublisher;
+import dev.cuong.payment.domain.event.TransactionEventType;
+import dev.cuong.payment.domain.model.Account;
+import dev.cuong.payment.domain.model.Transaction;
+import dev.cuong.payment.domain.vo.TransactionStatus;
+import dev.cuong.payment.infrastructure.persistence.entity.AuditLogJpaEntity;
+import dev.cuong.payment.infrastructure.persistence.repository.AuditLogJpaRepository;
+import dev.cuong.payment.presentation.auth.RegisterRequest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Integration test for {@link AuditConsumer}.
+ *
+ * <p>Uses real Postgres and Kafka. Redis is excluded — the audit consumer has no Redis
+ * dependency. A registered user's account provides a valid {@code fromAccountId} so the
+ * consumer can resolve {@code userId} from the DB without a fallback.
+ *
+ * <p>Tests are NOT {@code @Transactional}: the Kafka consumer runs in its own thread and
+ * transaction. Awaitility polls the {@link AuditLogJpaRepository} until the expected
+ * number of rows appear.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@Testcontainers
+@TestPropertySource(properties = {
+        "spring.autoconfigure.exclude=org.redisson.spring.starter.RedissonAutoConfigurationV2",
+        "spring.flyway.enabled=true",
+        "spring.flyway.validate-on-migrate=true",
+        "spring.jpa.hibernate.ddl-auto=validate",
+        "app.jwt.secret=test-secret-key-minimum-32-chars-for-hs256!",
+        "app.rate-limit.max-requests-per-minute=1000"
+})
+class AuditConsumerIntegrationTest {
+
+    static final KafkaContainer kafka =
+            new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.6.1"));
+
+    static final PostgreSQLContainer<?> postgres =
+            new PostgreSQLContainer<>("postgres:15-alpine");
+
+    static {
+        kafka.start();
+        postgres.start();
+    }
+
+    @DynamicPropertySource
+    static void overrideProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.kafka.bootstrap-servers", kafka::getBootstrapServers);
+        registry.add("spring.datasource.url", postgres::getJdbcUrl);
+        registry.add("spring.datasource.username", postgres::getUsername);
+        registry.add("spring.datasource.password", postgres::getPassword);
+    }
+
+    @Autowired MockMvc mockMvc;
+    @Autowired ObjectMapper objectMapper;
+    @Autowired EventPublisher eventPublisher;
+    @Autowired AccountRepository accountRepository;
+    @Autowired AuditLogJpaRepository auditLogJpaRepository;
+
+    // ── Core: every published event produces an audit entry ───────────────────
+
+    @Test
+    void should_insert_audit_entry_for_every_published_event() throws Exception {
+        // Register a user so the consumer can resolve userId from fromAccountId
+        String token     = registerAndGetToken("audit-alice", "audit-alice@test.com");
+        UUID   userId    = extractUserId(token);
+        UUID   fromAccId = accountRepository.findByUserId(userId).orElseThrow().getId();
+
+        UUID txId = UUID.randomUUID();
+
+        // Publish 3 events for this transaction (skip CREATED to avoid noisy retries
+        // from TransactionProcessingConsumer which looks up the transaction row in DB)
+        publishEvent(txId, fromAccId, TransactionStatus.PROCESSING, TransactionEventType.PROCESSING);
+        publishEvent(txId, fromAccId, TransactionStatus.SUCCESS,    TransactionEventType.SUCCESS);
+        publishEvent(txId, fromAccId, TransactionStatus.REFUNDED,   TransactionEventType.REFUNDED);
+
+        await().atMost(10, SECONDS).untilAsserted(() ->
+                assertThat(auditLogJpaRepository.countByTransactionId(txId)).isEqualTo(3));
+
+        List<AuditLogJpaEntity> entries =
+                auditLogJpaRepository.findByTransactionIdOrderByCreatedAtAsc(txId);
+
+        assertThat(entries).extracting(AuditLogJpaEntity::getEventType)
+                .containsExactlyInAnyOrder("PROCESSING", "SUCCESS", "REFUNDED");
+
+        assertThat(entries).allSatisfy(e -> {
+            assertThat(e.getTransactionId()).isEqualTo(txId);
+            assertThat(e.getUserId()).isEqualTo(userId);          // resolved from account
+            assertThat(e.getNewStatus()).isNotBlank();
+            assertThat(e.getMetadata()).isNotBlank();
+            assertThat(e.getCreatedAt()).isNotNull();
+        });
+    }
+
+    // ── Metadata contains event fields ────────────────────────────────────────
+
+    @Test
+    void should_persist_metadata_with_amount_and_account_ids() throws Exception {
+        String token     = registerAndGetToken("audit-bob", "audit-bob@test.com");
+        UUID   userId    = extractUserId(token);
+        UUID   fromAccId = accountRepository.findByUserId(userId).orElseThrow().getId();
+
+        UUID txId      = UUID.randomUUID();
+        UUID toAccId   = UUID.randomUUID();
+        BigDecimal amt = new BigDecimal("750.00");
+
+        Transaction tx = Transaction.builder()
+                .id(txId)
+                .fromAccountId(fromAccId)
+                .toAccountId(toAccId)
+                .amount(amt)
+                .currency("USD")
+                .status(TransactionStatus.SUCCESS)
+                .description("Audit metadata test")
+                .idempotencyKey(UUID.randomUUID().toString())
+                .retryCount(0)
+                .createdAt(Instant.now())
+                .updatedAt(Instant.now())
+                .build();
+
+        eventPublisher.publish(tx, TransactionEventType.SUCCESS);
+
+        await().atMost(10, SECONDS).untilAsserted(() ->
+                assertThat(auditLogJpaRepository.countByTransactionId(txId)).isEqualTo(1));
+
+        AuditLogJpaEntity entry =
+                auditLogJpaRepository.findByTransactionIdOrderByCreatedAtAsc(txId).get(0);
+
+        assertThat(entry.getEventType()).isEqualTo("SUCCESS");
+        assertThat(entry.getNewStatus()).isEqualTo("SUCCESS");
+        assertThat(entry.getMetadata()).contains("750");
+        assertThat(entry.getMetadata()).contains(fromAccId.toString());
+        assertThat(entry.getMetadata()).contains(toAccId.toString());
+        assertThat(entry.getMetadata()).contains("USD");
+    }
+
+    // ── Each event type produces its own row (append-only) ───────────────────
+
+    @Test
+    void should_produce_separate_immutable_rows_for_each_event_not_update_existing() throws Exception {
+        String token     = registerAndGetToken("audit-carol", "audit-carol@test.com");
+        UUID   userId    = extractUserId(token);
+        UUID   fromAccId = accountRepository.findByUserId(userId).orElseThrow().getId();
+
+        UUID txId = UUID.randomUUID();
+
+        publishEvent(txId, fromAccId, TransactionStatus.PROCESSING, TransactionEventType.PROCESSING);
+        publishEvent(txId, fromAccId, TransactionStatus.SUCCESS,    TransactionEventType.SUCCESS);
+
+        await().atMost(10, SECONDS).untilAsserted(() ->
+                assertThat(auditLogJpaRepository.countByTransactionId(txId)).isEqualTo(2));
+
+        // Both rows exist with distinct IDs — proof of append-only, no UPDATE
+        List<AuditLogJpaEntity> entries =
+                auditLogJpaRepository.findByTransactionIdOrderByCreatedAtAsc(txId);
+        assertThat(entries).extracting(AuditLogJpaEntity::getId).doesNotHaveDuplicates();
+        assertThat(entries).extracting(AuditLogJpaEntity::getEventType)
+                .containsExactly("PROCESSING", "SUCCESS");
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private void publishEvent(UUID txId, UUID fromAccId,
+                              TransactionStatus status, TransactionEventType type) {
+        Transaction tx = Transaction.builder()
+                .id(txId)
+                .fromAccountId(fromAccId)
+                .toAccountId(UUID.randomUUID())
+                .amount(new BigDecimal("100.00"))
+                .currency("USD")
+                .status(status)
+                .description("Audit test")
+                .idempotencyKey(UUID.randomUUID().toString())
+                .retryCount(0)
+                .createdAt(Instant.now())
+                .updatedAt(Instant.now())
+                .build();
+        eventPublisher.publish(tx, type);
+    }
+
+    private String registerAndGetToken(String username, String email) throws Exception {
+        MvcResult result = mockMvc.perform(post("/api/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                new RegisterRequest(username, email, "password123"))))
+                .andExpect(status().isCreated())
+                .andReturn();
+        return objectMapper.readTree(result.getResponse().getContentAsString()).get("token").asText();
+    }
+
+    private UUID extractUserId(String token) throws Exception {
+        MvcResult result = mockMvc.perform(get("/api/users/me")
+                        .header("Authorization", "Bearer " + token))
+                .andReturn();
+        return UUID.fromString(
+                objectMapper.readTree(result.getResponse().getContentAsString()).get("id").asText());
+    }
+}

--- a/backend/src/test/java/dev/cuong/payment/infrastructure/kafka/NotificationConsumerIntegrationTest.java
+++ b/backend/src/test/java/dev/cuong/payment/infrastructure/kafka/NotificationConsumerIntegrationTest.java
@@ -1,0 +1,192 @@
+package dev.cuong.payment.infrastructure.kafka;
+
+import dev.cuong.payment.application.port.out.EventPublisher;
+import dev.cuong.payment.domain.event.TransactionEventType;
+import dev.cuong.payment.domain.model.Transaction;
+import dev.cuong.payment.domain.vo.TransactionStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.TestPropertySource;
+import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.EnumSet;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration test for {@link NotificationConsumer}.
+ *
+ * <p>A secondary test listener in group {@code test-notification-group} captures messages
+ * that arrive on the topic. Because consumer groups are independent, both the
+ * {@link NotificationConsumer} (group {@code notification}) and the test listener receive
+ * every published message — verifying both Kafka delivery and consumer group isolation.
+ *
+ * <p>Redis is not required for this consumer; Redisson is excluded so this test starts faster.
+ */
+@SpringBootTest
+@Testcontainers
+@TestPropertySource(properties = {
+        // Only Redisson excluded — this consumer needs Kafka but not Redis
+        "spring.autoconfigure.exclude=org.redisson.spring.starter.RedissonAutoConfigurationV2",
+        "spring.flyway.enabled=true",
+        "spring.flyway.validate-on-migrate=true",
+        "spring.jpa.hibernate.ddl-auto=validate",
+        "app.jwt.secret=test-secret-key-minimum-32-chars-for-hs256!"
+})
+class NotificationConsumerIntegrationTest {
+
+    static final KafkaContainer kafka =
+            new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.6.1"));
+
+    static final PostgreSQLContainer<?> postgres =
+            new PostgreSQLContainer<>("postgres:15-alpine");
+
+    static {
+        kafka.start();
+        postgres.start();
+    }
+
+    @DynamicPropertySource
+    static void overrideProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.kafka.bootstrap-servers", kafka::getBootstrapServers);
+        registry.add("spring.datasource.url", postgres::getJdbcUrl);
+        registry.add("spring.datasource.username", postgres::getUsername);
+        registry.add("spring.datasource.password", postgres::getPassword);
+    }
+
+    // ── Secondary test listener ───────────────────────────────────────────────
+
+    @TestConfiguration
+    static class TestListenerConfig {
+
+        static volatile CountDownLatch latch = new CountDownLatch(1);
+        static final Set<TransactionEventType> receivedTypes =
+                ConcurrentHashMap.newKeySet();
+
+        @Bean
+        TestNotificationListener testNotificationListener() {
+            return new TestNotificationListener();
+        }
+    }
+
+    static class TestNotificationListener {
+
+        @KafkaListener(
+                topics = "payment.transaction.events",
+                groupId = "test-notification-group"
+        )
+        void receive(TransactionEventMessage message) {
+            TestListenerConfig.receivedTypes.add(message.eventType());
+            TestListenerConfig.latch.countDown();
+        }
+    }
+
+    @Autowired
+    EventPublisher eventPublisher;
+
+    @BeforeEach
+    void resetCapture() {
+        TestListenerConfig.receivedTypes.clear();
+    }
+
+    // ── All event types delivered ─────────────────────────────────────────────
+
+    @Test
+    void should_receive_all_six_event_types_within_timeout() throws InterruptedException {
+        TestListenerConfig.latch = new CountDownLatch(6);
+
+        Transaction tx = buildTransaction(TransactionStatus.SUCCESS);
+
+        eventPublisher.publish(tx, TransactionEventType.CREATED);
+        eventPublisher.publish(tx, TransactionEventType.PROCESSING);
+        eventPublisher.publish(tx, TransactionEventType.SUCCESS);
+        eventPublisher.publish(tx, TransactionEventType.FAILED);
+        eventPublisher.publish(tx, TransactionEventType.TIMEOUT);
+        eventPublisher.publish(tx, TransactionEventType.REFUNDED);
+
+        boolean allDelivered = TestListenerConfig.latch.await(10, TimeUnit.SECONDS);
+        assertThat(allDelivered)
+                .as("Not all 6 event types were delivered to the topic within 10 s")
+                .isTrue();
+
+        assertThat(TestListenerConfig.receivedTypes)
+                .containsExactlyInAnyOrderElementsOf(
+                        EnumSet.allOf(TransactionEventType.class));
+    }
+
+    // ── Event metadata preserved end-to-end ──────────────────────────────────
+
+    @Test
+    void should_preserve_transaction_metadata_through_kafka_serialization() throws InterruptedException {
+        TestListenerConfig.latch = new CountDownLatch(1);
+
+        UUID txId = UUID.randomUUID();
+        Transaction tx = buildTransactionWithId(txId, TransactionStatus.PENDING);
+
+        eventPublisher.publish(tx, TransactionEventType.CREATED);
+
+        boolean received = TestListenerConfig.latch.await(5, TimeUnit.SECONDS);
+        assertThat(received).as("CREATED event not received within 5 s").isTrue();
+
+        // Verify the test listener received exactly the message that was published
+        assertThat(TestListenerConfig.receivedTypes)
+                .containsExactly(TransactionEventType.CREATED);
+    }
+
+    // ── Independent consumer group offset ────────────────────────────────────
+
+    @Test
+    void should_deliver_independently_of_processing_consumer_group() throws InterruptedException {
+        // The notification group is independent of payment-processor.
+        // Publishing a REFUNDED event (which payment-processor ignores) must still
+        // arrive at the notification consumer's group.
+        TestListenerConfig.latch = new CountDownLatch(1);
+
+        Transaction tx = buildTransaction(TransactionStatus.REFUNDED);
+
+        eventPublisher.publish(tx, TransactionEventType.REFUNDED);
+
+        boolean received = TestListenerConfig.latch.await(5, TimeUnit.SECONDS);
+        assertThat(received).as("REFUNDED event not received within 5 s").isTrue();
+        assertThat(TestListenerConfig.receivedTypes).contains(TransactionEventType.REFUNDED);
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private Transaction buildTransaction(TransactionStatus status) {
+        return buildTransactionWithId(UUID.randomUUID(), status);
+    }
+
+    private Transaction buildTransactionWithId(UUID id, TransactionStatus status) {
+        return Transaction.builder()
+                .id(id)
+                .fromAccountId(UUID.randomUUID())
+                .toAccountId(UUID.randomUUID())
+                .amount(new BigDecimal("250.00"))
+                .currency("USD")
+                .status(status)
+                .description("Notification test")
+                .idempotencyKey(UUID.randomUUID().toString())
+                .retryCount(0)
+                .createdAt(Instant.now())
+                .updatedAt(Instant.now())
+                .build();
+    }
+}


### PR DESCRIPTION
## What this PR does
Closes #15 

Adds NotificationConsumer - a Kafka consumer in group "notification" that listens to all
six transaction lifecycle events (CREATED, PROCESSING, SUCCESS, FAILED, TIMEOUT, REFUNDED)
and logs structured messages simulating email/SMS to sender and/or receiver. The consumer
group is fully independent of the payment-processor group from Task 12: both groups read
every message from payment.transaction.events with their own separate offsets.

## How to test

1. Start infrastructure: `docker-compose up -d`
2. Run integration tests:
   `./gradlew test --tests "*.NotificationConsumerIntegrationTest"`
3. Manual smoke test:
   - Create a transaction via `POST /api/transactions`
   - Watch application logs for `[NOTIFY] email→sender` and `[NOTIFY] email→receiver` lines
   - Observe the full lifecycle: CREATED → PROCESSING → SUCCESS each produce their own log line

## Technical decisions

**Single consumer class with no output port:** The task scope is "log simulated notifications."
Introducing a NotificationPort interface would be the right move when a real email/SMS gateway
is added (Task N+X), but doing it now is YAGNI. The switch expression dispatches cleanly to
private methods and the log messages are structured with enough context (transactionId, amount,
currency) to be useful.

**Secondary test listener pattern:** The NotificationConsumer only logs - it has no DB side
effect to assert on. Using a secondary @KafkaListener in a different consumer group (same
pattern as KafkaEventPublisherIntegrationTest) lets the test verify Kafka delivery and consumer
group isolation without introducing test hooks into production code.