### PR TITLE
Task/14 dlq

### DIFF
--- a/backend/src/main/java/dev/cuong/payment/application/dto/CircuitBreakerStatusResult.java
+++ b/backend/src/main/java/dev/cuong/payment/application/dto/CircuitBreakerStatusResult.java
@@ -1,0 +1,21 @@
+package dev.cuong.payment.application.dto;
+
+/**
+ * Snapshot of the {@code payment-gateway} circuit breaker state.
+ * Passed from the admin service to the presentation layer.
+ *
+ * @param name            circuit breaker name
+ * @param state           current state: CLOSED, OPEN, HALF_OPEN, DISABLED, or FORCED_OPEN
+ * @param failureRate     percentage of failed calls in the sliding window (-1 if not enough calls yet)
+ * @param slowCallRate    percentage of slow calls in the sliding window (-1 if not enough calls yet)
+ * @param bufferedCalls   number of calls recorded in the sliding window
+ * @param failedCalls     number of failed calls in the sliding window
+ */
+public record CircuitBreakerStatusResult(
+        String name,
+        String state,
+        float failureRate,
+        float slowCallRate,
+        int bufferedCalls,
+        int failedCalls
+) {}

--- a/backend/src/main/java/dev/cuong/payment/application/dto/DlqEventResult.java
+++ b/backend/src/main/java/dev/cuong/payment/application/dto/DlqEventResult.java
@@ -1,0 +1,27 @@
+package dev.cuong.payment.application.dto;
+
+import dev.cuong.payment.domain.event.TransactionEventType;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * Read model representing a single dead-letter event — passed from service to presentation layer.
+ *
+ * @param transactionId pre-parsed from payload JSON; {@code null} if payload was unreadable
+ * @param eventType     pre-parsed from payload JSON; {@code null} if payload was unreadable
+ */
+public record DlqEventResult(
+        UUID id,
+        String topic,
+        Integer kafkaPartition,
+        Long kafkaOffset,
+        String payload,
+        UUID transactionId,
+        TransactionEventType eventType,
+        String errorMessage,
+        int retryCount,
+        Instant createdAt,
+        Instant resolvedAt,
+        String resolvedBy
+) {}

--- a/backend/src/main/java/dev/cuong/payment/application/port/in/AdminUseCase.java
+++ b/backend/src/main/java/dev/cuong/payment/application/port/in/AdminUseCase.java
@@ -1,0 +1,57 @@
+package dev.cuong.payment.application.port.in;
+
+import dev.cuong.payment.application.dto.CircuitBreakerStatusResult;
+import dev.cuong.payment.application.dto.DlqEventResult;
+import dev.cuong.payment.application.dto.PagedResult;
+import dev.cuong.payment.application.dto.TransactionResult;
+import dev.cuong.payment.domain.vo.TransactionStatus;
+
+import java.util.UUID;
+
+/**
+ * Admin use cases — all methods must be called by a user with the ADMIN role.
+ *
+ * <p>Role enforcement is performed at the {@link dev.cuong.payment.presentation.admin.AdminController}
+ * layer via {@code @PreAuthorize("hasRole('ADMIN')")}. The service itself does not re-check
+ * the role — it trusts that the presentation layer has already verified authorization.
+ */
+public interface AdminUseCase {
+
+    /**
+     * Returns a paginated list of dead-letter events, newest first.
+     *
+     * @param page zero-based page index
+     * @param size maximum number of items per page
+     */
+    PagedResult<DlqEventResult> getDlqEvents(int page, int size);
+
+    /**
+     * Re-publishes a dead-letter event to the main Kafka topic and marks it resolved.
+     *
+     * <p>The original event type is preserved: if a PROCESSING event failed in the audit
+     * consumer, the retry re-publishes a PROCESSING event — giving every consumer
+     * (notification, audit) another chance. The processing consumer ignores non-CREATED events,
+     * so re-publishing non-CREATED events does not cause double payment processing.
+     *
+     * <p>If the DLQ event has already been resolved, the call is a no-op (idempotent).
+     *
+     * @param dlqEventId the ID of the DLQ record to retry
+     * @throws dev.cuong.payment.domain.exception.DlqEventNotFoundException if no event with that ID exists
+     */
+    void retryDlqEvent(UUID dlqEventId);
+
+    /**
+     * Returns all transactions across all users, optionally filtered by status.
+     *
+     * @param status optional status filter; {@code null} returns all statuses
+     * @param page   zero-based page index
+     * @param size   maximum number of items per page
+     */
+    PagedResult<TransactionResult> getAllTransactions(TransactionStatus status, int page, int size);
+
+    /**
+     * Returns the current state and call metrics of the {@code payment-gateway} circuit breaker.
+     * Metrics values are -1 when the sliding window does not yet have enough data.
+     */
+    CircuitBreakerStatusResult getCircuitBreakerStatus();
+}

--- a/backend/src/main/java/dev/cuong/payment/application/port/out/DeadLetterRepository.java
+++ b/backend/src/main/java/dev/cuong/payment/application/port/out/DeadLetterRepository.java
@@ -1,0 +1,100 @@
+package dev.cuong.payment.application.port.out;
+
+import dev.cuong.payment.domain.event.TransactionEventType;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Output port for persisting and querying dead-letter events.
+ *
+ * <p>Dead-letter events are Kafka messages that failed consumer processing after the
+ * maximum number of retries. They are stored here so administrators can inspect the
+ * payload, investigate the root cause, and trigger re-delivery to the main topic.
+ *
+ * <p>Records in this store are append-only — the only mutation allowed is setting
+ * {@code resolvedAt} when an admin retries or discards an event.
+ */
+public interface DeadLetterRepository {
+
+    /**
+     * Persists a new dead-letter entry produced by the Kafka error handler.
+     *
+     * @param entry the raw failure metadata — never update after insert
+     */
+    void save(DeadLetterEntry entry);
+
+    /**
+     * Returns paginated dead-letter events, newest first.
+     *
+     * @param page zero-based page index
+     * @param size maximum number of items per page
+     */
+    List<DlqEvent> findAll(int page, int size);
+
+    /** Total count of all dead-letter events (resolved + pending). */
+    long count();
+
+    /**
+     * Returns a single DLQ event with pre-parsed {@code transactionId} and {@code eventType}.
+     * The adapter performs the JSON parsing so the application service remains free of
+     * infrastructure knowledge.
+     *
+     * @param id the DLQ event identifier
+     * @return the event, or empty if not found
+     */
+    Optional<DlqEvent> findById(UUID id);
+
+    /**
+     * Marks the event as resolved — called by the admin retry or discard flow.
+     *
+     * @param id         the DLQ event to resolve
+     * @param resolvedBy description of who/what resolved it (e.g. "admin-retry:{userId}")
+     */
+    void markResolved(UUID id, String resolvedBy);
+
+    // ── Nested types ──────────────────────────────────────────────────────────
+
+    /**
+     * Payload supplied by the Kafka error handler to persist a failed message.
+     *
+     * @param topic          the Kafka topic the message was consumed from
+     * @param kafkaPartition the partition (nullable when failure precedes partition assignment)
+     * @param kafkaOffset    the offset within the partition (nullable for the same reason)
+     * @param payload        JSON-serialized message value as a string
+     * @param errorMessage   the exception message from the final processing attempt
+     */
+    record DeadLetterEntry(
+            String topic,
+            Integer kafkaPartition,
+            Long kafkaOffset,
+            String payload,
+            String errorMessage
+    ) {}
+
+    /**
+     * Read model returned by find operations.
+     *
+     * <p>The adapter pre-parses {@code transactionId} and {@code eventType} from the raw
+     * JSON payload so the service layer never needs to deal with JSON directly.
+     *
+     * @param transactionId parsed from the payload; {@code null} if payload was corrupt
+     * @param eventType     parsed from the payload; {@code null} if payload was corrupt
+     */
+    record DlqEvent(
+            UUID id,
+            String topic,
+            Integer kafkaPartition,
+            Long kafkaOffset,
+            String payload,
+            UUID transactionId,
+            TransactionEventType eventType,
+            String errorMessage,
+            int retryCount,
+            Instant createdAt,
+            Instant resolvedAt,
+            String resolvedBy
+    ) {}
+}

--- a/backend/src/main/java/dev/cuong/payment/application/port/out/TransactionRepository.java
+++ b/backend/src/main/java/dev/cuong/payment/application/port/out/TransactionRepository.java
@@ -31,4 +31,16 @@ public interface TransactionRepository {
     Optional<Transaction> findByIdempotencyKey(String idempotencyKey);
 
     Transaction save(Transaction transaction);
+
+    // ── Admin-scoped methods (not filtered by fromAccountId) ──────────────────
+
+    /** Returns all transactions across all users, newest first. */
+    List<Transaction> findAllTransactions(int page, int size);
+
+    /** Returns all transactions for a given status across all users, newest first. */
+    List<Transaction> findAllTransactionsByStatus(TransactionStatus status, int page, int size);
+
+    long countAllTransactions();
+
+    long countAllTransactionsByStatus(TransactionStatus status);
 }

--- a/backend/src/main/java/dev/cuong/payment/application/service/AdminService.java
+++ b/backend/src/main/java/dev/cuong/payment/application/service/AdminService.java
@@ -1,0 +1,144 @@
+package dev.cuong.payment.application.service;
+
+import dev.cuong.payment.application.dto.CircuitBreakerStatusResult;
+import dev.cuong.payment.application.dto.DlqEventResult;
+import dev.cuong.payment.application.dto.PagedResult;
+import dev.cuong.payment.application.dto.TransactionResult;
+import dev.cuong.payment.application.port.in.AdminUseCase;
+import dev.cuong.payment.application.port.out.DeadLetterRepository;
+import dev.cuong.payment.application.port.out.DeadLetterRepository.DlqEvent;
+import dev.cuong.payment.application.port.out.EventPublisher;
+import dev.cuong.payment.application.port.out.TransactionRepository;
+import dev.cuong.payment.domain.exception.DlqEventNotFoundException;
+import dev.cuong.payment.domain.exception.TransactionNotFoundException;
+import dev.cuong.payment.domain.model.Transaction;
+import dev.cuong.payment.domain.vo.TransactionStatus;
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AdminService implements AdminUseCase {
+
+    private static final String CIRCUIT_BREAKER_NAME = "payment-gateway";
+
+    private final DeadLetterRepository deadLetterRepository;
+    private final TransactionRepository transactionRepository;
+    private final EventPublisher eventPublisher;
+    private final CircuitBreakerRegistry circuitBreakerRegistry;
+
+    @Override
+    public PagedResult<DlqEventResult> getDlqEvents(int page, int size) {
+        List<DlqEventResult> results = deadLetterRepository.findAll(page, size)
+                .stream()
+                .map(this::toDlqResult)
+                .toList();
+        long total = deadLetterRepository.count();
+        int totalPages = size > 0 ? (int) Math.ceil((double) total / size) : 0;
+        return new PagedResult<>(results, page, size, total, totalPages);
+    }
+
+    @Override
+    @Transactional
+    public void retryDlqEvent(UUID dlqEventId) {
+        DlqEvent event = deadLetterRepository.findById(dlqEventId)
+                .orElseThrow(() -> new DlqEventNotFoundException(dlqEventId));
+
+        if (event.resolvedAt() != null) {
+            log.warn("[ADMIN] DLQ event already resolved — ignoring retry: dlqEventId={}", dlqEventId);
+            return;
+        }
+
+        if (event.transactionId() == null || event.eventType() == null) {
+            log.warn("[ADMIN] Cannot retry DLQ event — transactionId or eventType missing " +
+                    "(payload was unreadable): dlqEventId={}", dlqEventId);
+            deadLetterRepository.markResolved(dlqEventId, "admin-discard:unreadable-payload");
+            return;
+        }
+
+        Transaction tx = transactionRepository.findById(event.transactionId())
+                .orElseThrow(() -> new TransactionNotFoundException(event.transactionId()));
+
+        eventPublisher.publish(tx, event.eventType());
+        deadLetterRepository.markResolved(dlqEventId, "admin-retry");
+
+        log.info("[ADMIN] DLQ event retried: dlqEventId={}, transactionId={}, eventType={}",
+                dlqEventId, event.transactionId(), event.eventType());
+    }
+
+    @Override
+    public PagedResult<TransactionResult> getAllTransactions(TransactionStatus status, int page, int size) {
+        List<Transaction> transactions;
+        long total;
+
+        if (status == null) {
+            transactions = transactionRepository.findAllTransactions(page, size);
+            total = transactionRepository.countAllTransactions();
+        } else {
+            transactions = transactionRepository.findAllTransactionsByStatus(status, page, size);
+            total = transactionRepository.countAllTransactionsByStatus(status);
+        }
+
+        int totalPages = size > 0 ? (int) Math.ceil((double) total / size) : 0;
+        List<TransactionResult> results = transactions.stream().map(this::toTransactionResult).toList();
+        return new PagedResult<>(results, page, size, total, totalPages);
+    }
+
+    @Override
+    public CircuitBreakerStatusResult getCircuitBreakerStatus() {
+        CircuitBreaker cb = circuitBreakerRegistry.circuitBreaker(CIRCUIT_BREAKER_NAME);
+        CircuitBreaker.Metrics metrics = cb.getMetrics();
+
+        // Resilience4j returns -1.0 when not enough calls have been recorded yet
+        float failureRate  = Math.max(metrics.getFailureRate(),  -1f);
+        float slowCallRate = Math.max(metrics.getSlowCallRate(), -1f);
+
+        return new CircuitBreakerStatusResult(
+                CIRCUIT_BREAKER_NAME,
+                cb.getState().name(),
+                failureRate,
+                slowCallRate,
+                metrics.getNumberOfBufferedCalls(),
+                metrics.getNumberOfFailedCalls()
+        );
+    }
+
+    // ── Private helpers ───────────────────────────────────────────────────────
+
+    private DlqEventResult toDlqResult(DlqEvent e) {
+        return new DlqEventResult(
+                e.id(), e.topic(), e.kafkaPartition(), e.kafkaOffset(),
+                e.payload(), e.transactionId(), e.eventType(),
+                e.errorMessage(), e.retryCount(),
+                e.createdAt(), e.resolvedAt(), e.resolvedBy()
+        );
+    }
+
+    private TransactionResult toTransactionResult(Transaction tx) {
+        return new TransactionResult(
+                tx.getId(),
+                tx.getFromAccountId(),
+                tx.getToAccountId(),
+                tx.getAmount(),
+                tx.getCurrency(),
+                tx.getStatus().name(),
+                tx.getDescription(),
+                tx.getIdempotencyKey(),
+                tx.getGatewayReference(),
+                tx.getFailureReason(),
+                tx.getRetryCount(),
+                tx.getProcessedAt(),
+                tx.getRefundedAt(),
+                tx.getCreatedAt(),
+                tx.getUpdatedAt()
+        );
+    }
+}

--- a/backend/src/main/java/dev/cuong/payment/domain/exception/DlqEventNotFoundException.java
+++ b/backend/src/main/java/dev/cuong/payment/domain/exception/DlqEventNotFoundException.java
@@ -1,0 +1,10 @@
+package dev.cuong.payment.domain.exception;
+
+import java.util.UUID;
+
+public class DlqEventNotFoundException extends DomainException {
+
+    public DlqEventNotFoundException(UUID dlqEventId) {
+        super("Dead-letter event not found: " + dlqEventId);
+    }
+}

--- a/backend/src/main/java/dev/cuong/payment/infrastructure/kafka/KafkaConfig.java
+++ b/backend/src/main/java/dev/cuong/payment/infrastructure/kafka/KafkaConfig.java
@@ -1,14 +1,21 @@
 package dev.cuong.payment.infrastructure.kafka;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.cuong.payment.application.port.out.DeadLetterRepository;
 import dev.cuong.payment.application.port.out.EventPublisher;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.TopicPartition;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.kafka.config.TopicBuilder;
 import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.listener.CommonErrorHandler;
+import org.springframework.kafka.listener.ConsumerRecordRecoverer;
+import org.springframework.kafka.listener.DeadLetterPublishingRecoverer;
 import org.springframework.kafka.listener.DefaultErrorHandler;
 import org.springframework.util.backoff.FixedBackOff;
 
@@ -52,14 +59,116 @@ public class KafkaConfig {
     }
 
     /**
-     * Retries failed consumer records up to 2 times with a 1-second delay before
-     * the record is logged and discarded (or forwarded to DLQ in Task 15).
-     * {@link org.springframework.dao.OptimisticLockingFailureException} is caught inside
-     * the consumer and never propagates here — only truly unexpected failures retry.
+     * Error handler that retries failed consumer records up to 2 times (1-second delay)
+     * and then routes the message to the DLQ.
+     *
+     * <p>On exhaustion the {@link PersistingDlqRecoverer} (a) persists the raw payload and
+     * error details to {@code dead_letter_events}, then (b) publishes the record to the Kafka
+     * DLQ topic via {@link DeadLetterPublishingRecoverer}. DB is written first: if Kafka publish
+     * fails the admin still sees the entry in the DB and can retry manually.
+     *
+     * <p>Falls back to a logging-only handler when {@code KafkaTemplate} is unavailable
+     * (tests that exclude {@code KafkaAutoConfiguration}).
      */
     @Bean
-    public DefaultErrorHandler kafkaErrorHandler() {
-        return new DefaultErrorHandler(new FixedBackOff(1000L, 2L));
+    public CommonErrorHandler kafkaErrorHandler(
+            @SuppressWarnings("rawtypes") ObjectProvider<KafkaTemplate> kafkaTemplateProvider,
+            DeadLetterRepository deadLetterRepository,
+            ObjectMapper objectMapper) {
+
+        @SuppressWarnings({"rawtypes", "unchecked"})
+        KafkaTemplate<Object, Object> kafkaTemplate =
+                (KafkaTemplate<Object, Object>) (KafkaTemplate) kafkaTemplateProvider.getIfAvailable();
+
+        if (kafkaTemplate == null) {
+            log.warn("[DLQ] Kafka unavailable — DLQ recovery disabled; failed messages will be logged only");
+            return new DefaultErrorHandler(new FixedBackOff(1000L, 2L));
+        }
+
+        DeadLetterPublishingRecoverer dlqPublisher = new DeadLetterPublishingRecoverer(
+                kafkaTemplate,
+                // DLQ topic has 1 partition; always route to partition 0
+                (record, ex) -> new TopicPartition(transactionDlqTopic, 0));
+
+        ConsumerRecordRecoverer recoverer =
+                new PersistingDlqRecoverer(dlqPublisher, deadLetterRepository, objectMapper);
+
+        return new DefaultErrorHandler(recoverer, new FixedBackOff(1000L, 2L));
+    }
+
+    /**
+     * Wraps {@link DeadLetterPublishingRecoverer} to persist the failed record to
+     * {@code dead_letter_events} before forwarding to the Kafka DLQ topic.
+     *
+     * <p>DB write is attempted first so that even a Kafka DLQ publish failure does not
+     * result in a completely invisible failure. Any persistence error is logged but does
+     * not prevent the Kafka publish from being attempted.
+     */
+    private static class PersistingDlqRecoverer implements ConsumerRecordRecoverer {
+
+        private final DeadLetterPublishingRecoverer delegate;
+        private final DeadLetterRepository deadLetterRepository;
+        private final ObjectMapper objectMapper;
+
+        PersistingDlqRecoverer(DeadLetterPublishingRecoverer delegate,
+                               DeadLetterRepository deadLetterRepository,
+                               ObjectMapper objectMapper) {
+            this.delegate = delegate;
+            this.deadLetterRepository = deadLetterRepository;
+            this.objectMapper = objectMapper;
+        }
+
+        @Override
+        public void accept(ConsumerRecord<?, ?> record, Exception exception) {
+            persistToDb(record, exception);
+            try {
+                delegate.accept(record, exception);
+            } catch (Exception e) {
+                // DB entry is already written — Kafka DLQ publish is best-effort.
+                // Do NOT rethrow: Spring Kafka must see recovery as successful so it
+                // commits the offset. If we propagate, the container retries forever.
+                log.error("[DLQ] Kafka DLQ publish failed — record is in DB for admin retry: " +
+                                "topic={}, partition={}, offset={}, error={}",
+                        record.topic(), record.partition(), record.offset(), e.getMessage(), e);
+            }
+        }
+
+        private void persistToDb(ConsumerRecord<?, ?> record, Exception exception) {
+            try {
+                String payload = serializeValue(record.value());
+                // Unwrap Spring Kafka's ListenerExecutionFailedException to get the real error message
+                String errorMessage = rootCauseMessage(exception);
+
+                deadLetterRepository.save(new DeadLetterRepository.DeadLetterEntry(
+                        record.topic(),
+                        record.partition(),
+                        record.offset(),
+                        payload,
+                        errorMessage
+                ));
+            } catch (Exception e) {
+                log.error("[DLQ] Failed to persist dead-letter entry to DB: " +
+                                "topic={}, partition={}, offset={}, error={}",
+                        record.topic(), record.partition(), record.offset(), e.getMessage(), e);
+            }
+        }
+
+        private static String rootCauseMessage(Throwable t) {
+            Throwable root = t;
+            while (root.getCause() != null) {
+                root = root.getCause();
+            }
+            return root.getMessage() != null ? root.getMessage() : root.getClass().getName();
+        }
+
+        private String serializeValue(Object value) {
+            if (value == null) return "null";
+            try {
+                return objectMapper.writeValueAsString(value);
+            } catch (Exception e) {
+                return String.valueOf(value);
+            }
+        }
     }
 
     @SuppressWarnings({"rawtypes", "unchecked"})

--- a/backend/src/main/java/dev/cuong/payment/infrastructure/persistence/adapter/DeadLetterRepositoryAdapter.java
+++ b/backend/src/main/java/dev/cuong/payment/infrastructure/persistence/adapter/DeadLetterRepositoryAdapter.java
@@ -1,0 +1,100 @@
+package dev.cuong.payment.infrastructure.persistence.adapter;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.cuong.payment.application.port.out.DeadLetterRepository;
+import dev.cuong.payment.domain.event.TransactionEventType;
+import dev.cuong.payment.infrastructure.persistence.entity.DeadLetterEventJpaEntity;
+import dev.cuong.payment.infrastructure.persistence.repository.DeadLetterEventJpaRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class DeadLetterRepositoryAdapter implements DeadLetterRepository {
+
+    private final DeadLetterEventJpaRepository jpaRepository;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void save(DeadLetterEntry entry) {
+        DeadLetterEventJpaEntity entity = DeadLetterEventJpaEntity.builder()
+                .topic(entry.topic())
+                .kafkaPartition(entry.kafkaPartition())
+                .kafkaOffset(entry.kafkaOffset())
+                .payload(entry.payload())
+                .errorMessage(truncate(entry.errorMessage(), 2000))
+                .build();
+        jpaRepository.save(entity);
+    }
+
+    @Override
+    public List<DlqEvent> findAll(int page, int size) {
+        PageRequest pageable = PageRequest.of(page, size, Sort.by("createdAt").descending());
+        return jpaRepository.findAllByOrderByCreatedAtDesc(pageable)
+                .map(this::toDlqEvent)
+                .toList();
+    }
+
+    @Override
+    public long count() {
+        return jpaRepository.count();
+    }
+
+    @Override
+    public Optional<DlqEvent> findById(UUID id) {
+        return jpaRepository.findById(id).map(this::toDlqEvent);
+    }
+
+    @Override
+    public void markResolved(UUID id, String resolvedBy) {
+        jpaRepository.findById(id).ifPresent(entity -> {
+            entity.resolve(resolvedBy);
+            jpaRepository.save(entity);
+        });
+    }
+
+    // ── Private helpers ───────────────────────────────────────────────────────
+
+    private DlqEvent toDlqEvent(DeadLetterEventJpaEntity e) {
+        UUID transactionId = null;
+        TransactionEventType eventType = null;
+
+        // Parse transactionId and eventType from the JSON payload.
+        // Failures are non-fatal: callers receive null fields and handle gracefully.
+        try {
+            JsonNode node = objectMapper.readTree(e.getPayload());
+            JsonNode txIdNode = node.get("transactionId");
+            if (txIdNode != null && !txIdNode.isNull()) {
+                transactionId = UUID.fromString(txIdNode.asText());
+            }
+            JsonNode typeNode = node.get("eventType");
+            if (typeNode != null && !typeNode.isNull()) {
+                eventType = TransactionEventType.valueOf(typeNode.asText());
+            }
+        } catch (Exception parseEx) {
+            log.warn("[DLQ] Could not parse transactionId/eventType from payload: dlqId={}, error={}",
+                    e.getId(), parseEx.getMessage());
+        }
+
+        return new DlqEvent(
+                e.getId(), e.getTopic(), e.getKafkaPartition(), e.getKafkaOffset(),
+                e.getPayload(), transactionId, eventType,
+                e.getErrorMessage(), e.getRetryCount(),
+                e.getCreatedAt(), e.getResolvedAt(), e.getResolvedBy()
+        );
+    }
+
+    private static String truncate(String s, int maxLength) {
+        if (s == null) return "";
+        return s.length() <= maxLength ? s : s.substring(0, maxLength) + "…";
+    }
+}

--- a/backend/src/main/java/dev/cuong/payment/infrastructure/persistence/adapter/TransactionRepositoryAdapter.java
+++ b/backend/src/main/java/dev/cuong/payment/infrastructure/persistence/adapter/TransactionRepositoryAdapter.java
@@ -65,4 +65,30 @@ public class TransactionRepositoryAdapter implements TransactionRepository {
     public Transaction save(Transaction transaction) {
         return TransactionMapper.toDomain(jpaRepository.save(TransactionMapper.toEntity(transaction)));
     }
+
+    @Override
+    public List<Transaction> findAllTransactions(int page, int size) {
+        PageRequest pageable = PageRequest.of(page, size, Sort.by("createdAt").descending());
+        return jpaRepository.findAll(pageable)
+                .map(TransactionMapper::toDomain)
+                .toList();
+    }
+
+    @Override
+    public List<Transaction> findAllTransactionsByStatus(TransactionStatus status, int page, int size) {
+        PageRequest pageable = PageRequest.of(page, size, Sort.by("createdAt").descending());
+        return jpaRepository.findByStatus(status, pageable)
+                .map(TransactionMapper::toDomain)
+                .toList();
+    }
+
+    @Override
+    public long countAllTransactions() {
+        return jpaRepository.count();
+    }
+
+    @Override
+    public long countAllTransactionsByStatus(TransactionStatus status) {
+        return jpaRepository.countByStatus(status);
+    }
 }

--- a/backend/src/main/java/dev/cuong/payment/infrastructure/persistence/entity/DeadLetterEventJpaEntity.java
+++ b/backend/src/main/java/dev/cuong/payment/infrastructure/persistence/entity/DeadLetterEventJpaEntity.java
@@ -1,0 +1,68 @@
+package dev.cuong.payment.infrastructure.persistence.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * JPA entity for the {@code dead_letter_events} table.
+ *
+ * <p>Rows are inserted by the Kafka DLQ recoverer and updated (resolved_at, resolved_by)
+ * only when an admin retries or discards the event. No other mutations are allowed.
+ */
+@Entity
+@Table(name = "dead_letter_events")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class DeadLetterEventJpaEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(name = "topic", nullable = false, length = 255)
+    private String topic;
+
+    @Column(name = "kafka_partition")
+    private Integer kafkaPartition;
+
+    @Column(name = "kafka_offset")
+    private Long kafkaOffset;
+
+    // Raw JSON string of the original TransactionEventMessage — TEXT in Postgres, no length limit
+    @Column(name = "payload", nullable = false, columnDefinition = "text")
+    private String payload;
+
+    @Column(name = "error_message", nullable = false, columnDefinition = "text")
+    private String errorMessage;
+
+    @Column(name = "retry_count", nullable = false)
+    @Builder.Default
+    private int retryCount = 0;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @Column(name = "resolved_at")
+    private Instant resolvedAt;
+
+    @Column(name = "resolved_by", length = 255)
+    private String resolvedBy;
+
+    @PrePersist
+    void prePersist() {
+        if (createdAt == null) {
+            createdAt = Instant.now();
+        }
+    }
+
+    /** Called when an admin resolves this event via retry or discard. */
+    public void resolve(String resolvedBy) {
+        this.resolvedAt = Instant.now();
+        this.resolvedBy = resolvedBy;
+    }
+}

--- a/backend/src/main/java/dev/cuong/payment/infrastructure/persistence/repository/DeadLetterEventJpaRepository.java
+++ b/backend/src/main/java/dev/cuong/payment/infrastructure/persistence/repository/DeadLetterEventJpaRepository.java
@@ -1,0 +1,13 @@
+package dev.cuong.payment.infrastructure.persistence.repository;
+
+import dev.cuong.payment.infrastructure.persistence.entity.DeadLetterEventJpaEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface DeadLetterEventJpaRepository extends JpaRepository<DeadLetterEventJpaEntity, UUID> {
+
+    Page<DeadLetterEventJpaEntity> findAllByOrderByCreatedAtDesc(Pageable pageable);
+}

--- a/backend/src/main/java/dev/cuong/payment/infrastructure/persistence/repository/TransactionJpaRepository.java
+++ b/backend/src/main/java/dev/cuong/payment/infrastructure/persistence/repository/TransactionJpaRepository.java
@@ -22,4 +22,9 @@ public interface TransactionJpaRepository extends JpaRepository<TransactionJpaEn
     long countByFromAccountIdAndStatus(UUID fromAccountId, TransactionStatus status);
 
     Optional<TransactionJpaEntity> findByIdempotencyKey(String idempotencyKey);
+
+    // Admin-scoped queries — not filtered by fromAccountId
+    Page<TransactionJpaEntity> findByStatus(TransactionStatus status, Pageable pageable);
+
+    long countByStatus(TransactionStatus status);
 }

--- a/backend/src/main/java/dev/cuong/payment/presentation/admin/AdminController.java
+++ b/backend/src/main/java/dev/cuong/payment/presentation/admin/AdminController.java
@@ -1,0 +1,142 @@
+package dev.cuong.payment.presentation.admin;
+
+import dev.cuong.payment.application.dto.CircuitBreakerStatusResult;
+import dev.cuong.payment.application.dto.DlqEventResult;
+import dev.cuong.payment.application.dto.PagedResult;
+import dev.cuong.payment.application.dto.TransactionResult;
+import dev.cuong.payment.application.port.in.AdminUseCase;
+import dev.cuong.payment.domain.vo.TransactionStatus;
+import dev.cuong.payment.presentation.transaction.TransactionResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+/**
+ * Admin-only endpoints for DLQ management, cross-user transaction inspection,
+ * and circuit-breaker observability.
+ *
+ * <p>All methods require the caller to hold the {@code ADMIN} role. Role enforcement
+ * is applied at the class level via {@code @PreAuthorize} so it cannot be missed on
+ * individual methods.
+ */
+@RestController
+@RequestMapping("/api/admin")
+@RequiredArgsConstructor
+@PreAuthorize("hasRole('ADMIN')")
+public class AdminController {
+
+    private final AdminUseCase adminUseCase;
+
+    /**
+     * Returns a paginated list of dead-letter events, newest first.
+     *
+     * @return 200 with paginated DLQ events; 401 if unauthenticated; 403 if not ADMIN
+     */
+    @GetMapping("/dlq")
+    public ResponseEntity<PagedResult<DlqEventResponse>> getDlqEvents(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size) {
+
+        PagedResult<DlqEventResult> result = adminUseCase.getDlqEvents(page, size);
+        PagedResult<DlqEventResponse> response = new PagedResult<>(
+                result.data().stream().map(this::toDlqResponse).toList(),
+                result.page(),
+                result.size(),
+                result.totalElements(),
+                result.totalPages());
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * Re-publishes a dead-letter event to the main Kafka topic and marks it resolved.
+     * Idempotent: calling with an already-resolved event ID is a no-op (still returns 204).
+     *
+     * @param id the DLQ event identifier
+     * @return 204 on success; 404 if no event with that ID exists;
+     *         401 if unauthenticated; 403 if not ADMIN
+     */
+    @PostMapping("/dlq/{id}/retry")
+    public ResponseEntity<Void> retryDlqEvent(@PathVariable UUID id) {
+        adminUseCase.retryDlqEvent(id);
+        return ResponseEntity.noContent().build();
+    }
+
+    /**
+     * Returns all transactions across all users, optionally filtered by status.
+     * Paginated; newest first.
+     *
+     * @return 200 with paginated transactions; 401 if unauthenticated; 403 if not ADMIN
+     */
+    @GetMapping("/transactions")
+    public ResponseEntity<PagedResult<TransactionResponse>> getAllTransactions(
+            @RequestParam(required = false) TransactionStatus status,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size) {
+
+        PagedResult<TransactionResult> result = adminUseCase.getAllTransactions(status, page, size);
+        PagedResult<TransactionResponse> response = new PagedResult<>(
+                result.data().stream().map(this::toTransactionResponse).toList(),
+                result.page(),
+                result.size(),
+                result.totalElements(),
+                result.totalPages());
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * Returns the current state and call metrics of the {@code payment-gateway} circuit breaker.
+     * Metric values are -1 when the sliding window does not yet have enough data.
+     *
+     * @return 200 with circuit breaker status; 401 if unauthenticated; 403 if not ADMIN
+     */
+    @GetMapping("/circuit-breaker")
+    public ResponseEntity<CircuitBreakerStatusResponse> getCircuitBreakerStatus() {
+        CircuitBreakerStatusResult result = adminUseCase.getCircuitBreakerStatus();
+        return ResponseEntity.ok(new CircuitBreakerStatusResponse(
+                result.name(),
+                result.state(),
+                result.failureRate(),
+                result.slowCallRate(),
+                result.bufferedCalls(),
+                result.failedCalls()));
+    }
+
+    // ── Private mappers ───────────────────────────────────────────────────────
+
+    private DlqEventResponse toDlqResponse(DlqEventResult r) {
+        return new DlqEventResponse(
+                r.id().toString(),
+                r.topic(),
+                r.kafkaPartition(),
+                r.kafkaOffset(),
+                r.payload(),
+                r.transactionId() != null ? r.transactionId().toString() : null,
+                r.eventType()     != null ? r.eventType().name()        : null,
+                r.errorMessage(),
+                r.retryCount(),
+                r.createdAt(),
+                r.resolvedAt(),
+                r.resolvedBy());
+    }
+
+    private TransactionResponse toTransactionResponse(TransactionResult r) {
+        return new TransactionResponse(
+                r.id().toString(),
+                r.fromAccountId().toString(),
+                r.toAccountId().toString(),
+                r.amount(),
+                r.currency(),
+                r.status(),
+                r.description(),
+                r.gatewayReference(),
+                r.failureReason(),
+                r.retryCount(),
+                r.processedAt() != null ? r.processedAt().toString() : null,
+                r.refundedAt()  != null ? r.refundedAt().toString()  : null,
+                r.createdAt().toString(),
+                r.updatedAt().toString());
+    }
+}

--- a/backend/src/main/java/dev/cuong/payment/presentation/admin/CircuitBreakerStatusResponse.java
+++ b/backend/src/main/java/dev/cuong/payment/presentation/admin/CircuitBreakerStatusResponse.java
@@ -1,0 +1,10 @@
+package dev.cuong.payment.presentation.admin;
+
+public record CircuitBreakerStatusResponse(
+        String name,
+        String state,
+        float failureRate,
+        float slowCallRate,
+        int bufferedCalls,
+        int failedCalls
+) {}

--- a/backend/src/main/java/dev/cuong/payment/presentation/admin/DlqEventResponse.java
+++ b/backend/src/main/java/dev/cuong/payment/presentation/admin/DlqEventResponse.java
@@ -1,0 +1,18 @@
+package dev.cuong.payment.presentation.admin;
+
+import java.time.Instant;
+
+public record DlqEventResponse(
+        String id,
+        String topic,
+        Integer kafkaPartition,
+        Long kafkaOffset,
+        String payload,
+        String transactionId,
+        String eventType,
+        String errorMessage,
+        int retryCount,
+        Instant createdAt,
+        Instant resolvedAt,
+        String resolvedBy
+) {}

--- a/backend/src/main/java/dev/cuong/payment/presentation/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/dev/cuong/payment/presentation/exception/GlobalExceptionHandler.java
@@ -1,6 +1,8 @@
 package dev.cuong.payment.presentation.exception;
 
 import dev.cuong.payment.domain.exception.AccountNotFoundException;
+import dev.cuong.payment.domain.exception.DlqEventNotFoundException;
+import org.springframework.security.access.AccessDeniedException;
 import dev.cuong.payment.domain.exception.InvalidCredentialsException;
 import dev.cuong.payment.domain.exception.InvalidTransactionStateException;
 import dev.cuong.payment.domain.exception.TransactionNotFoundException;
@@ -42,7 +44,12 @@ public class GlobalExceptionHandler {
                 .body(new ApiError("INVALID_CREDENTIALS", e.getMessage()));
     }
 
-    @ExceptionHandler({TransactionNotFoundException.class, AccountNotFoundException.class, UserNotFoundException.class})
+    @ExceptionHandler({
+            TransactionNotFoundException.class,
+            AccountNotFoundException.class,
+            UserNotFoundException.class,
+            DlqEventNotFoundException.class
+    })
     public ResponseEntity<ApiError> handleNotFound(Exception e) {
         return ResponseEntity.status(HttpStatus.NOT_FOUND)
                 .body(new ApiError("NOT_FOUND", e.getMessage()));
@@ -101,6 +108,12 @@ public class GlobalExceptionHandler {
                 .collect(Collectors.joining("; "));
         return ResponseEntity.badRequest()
                 .body(new ApiError("VALIDATION_ERROR", message));
+    }
+
+    @ExceptionHandler(AccessDeniedException.class)
+    public ResponseEntity<ApiError> handleAccessDenied(AccessDeniedException e) {
+        return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                .body(new ApiError("ACCESS_DENIED", "You do not have permission to access this resource"));
     }
 
     @ExceptionHandler(Exception.class)

--- a/backend/src/test/java/dev/cuong/payment/infrastructure/kafka/DlqIntegrationTest.java
+++ b/backend/src/test/java/dev/cuong/payment/infrastructure/kafka/DlqIntegrationTest.java
@@ -1,0 +1,184 @@
+package dev.cuong.payment.infrastructure.kafka;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.cuong.payment.application.port.out.AccountRepository;
+import dev.cuong.payment.application.port.out.EventPublisher;
+import dev.cuong.payment.domain.event.TransactionEventType;
+import dev.cuong.payment.domain.model.Transaction;
+import dev.cuong.payment.domain.vo.TransactionStatus;
+import dev.cuong.payment.infrastructure.persistence.entity.DeadLetterEventJpaEntity;
+import dev.cuong.payment.infrastructure.persistence.repository.DeadLetterEventJpaRepository;
+import dev.cuong.payment.presentation.auth.RegisterRequest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.http.MediaType;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * End-to-end test for the DLQ path: consumer failure → retry exhaustion → DB persistence.
+ *
+ * <p>Uses real Postgres and Kafka. Redis is excluded — the DLQ path has no Redis dependency.
+ *
+ * <p>The inner {@code AlwaysFailConsumerConfig} registers a listener on the main topic with
+ * a dedicated group ("test-always-fail-group") that unconditionally throws. Spring Kafka's
+ * {@code kafkaErrorHandler} retries twice (FixedBackOff 1 s × 2), then calls
+ * the {@code PersistingDlqRecoverer} which writes the failure to {@code dead_letter_events}.
+ *
+ * <p>Tests are NOT {@code @Transactional}: the consumer and error handler run in separate
+ * threads with their own transactions. Awaitility polls until the expected DB row appears.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@Testcontainers
+@TestPropertySource(properties = {
+        "spring.autoconfigure.exclude=org.redisson.spring.starter.RedissonAutoConfigurationV2",
+        "spring.flyway.enabled=true",
+        "spring.flyway.validate-on-migrate=true",
+        "spring.jpa.hibernate.ddl-auto=validate",
+        "app.jwt.secret=test-secret-key-minimum-32-chars-for-hs256!",
+        "app.rate-limit.max-requests-per-minute=1000"
+})
+class DlqIntegrationTest {
+
+    static final KafkaContainer kafka =
+            new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.6.1"));
+
+    static final PostgreSQLContainer<?> postgres =
+            new PostgreSQLContainer<>("postgres:15-alpine");
+
+    static {
+        kafka.start();
+        postgres.start();
+    }
+
+    @DynamicPropertySource
+    static void overrideProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.kafka.bootstrap-servers", kafka::getBootstrapServers);
+        registry.add("spring.datasource.url", postgres::getJdbcUrl);
+        registry.add("spring.datasource.username", postgres::getUsername);
+        registry.add("spring.datasource.password", postgres::getPassword);
+    }
+
+    @Autowired MockMvc mockMvc;
+    @Autowired ObjectMapper objectMapper;
+    @Autowired EventPublisher eventPublisher;
+    @Autowired AccountRepository accountRepository;
+    @Autowired DeadLetterEventJpaRepository deadLetterEventJpaRepository;
+
+    // ── Core: exhausted retries produce a dead_letter_events row ─────────────
+
+    @Test
+    void should_persist_dlq_entry_when_consumer_fails_after_all_retries() throws Exception {
+        // Register a user so the AuditConsumer can resolve userId from fromAccountId
+        String token     = registerAndGetToken("dlq-alice", "dlq-alice@test.com");
+        UUID   userId    = extractUserId(token);
+        UUID   fromAccId = accountRepository.findByUserId(userId).orElseThrow().getId();
+
+        UUID txId    = UUID.randomUUID();
+        UUID toAccId = UUID.randomUUID();
+
+        // Publish a PROCESSING event (not CREATED, to avoid TransactionProcessingConsumer
+        // looking up a non-existent transaction row and creating unrelated DLQ entries)
+        Transaction tx = Transaction.builder()
+                .id(txId)
+                .fromAccountId(fromAccId)
+                .toAccountId(toAccId)
+                .amount(new BigDecimal("250.00"))
+                .currency("USD")
+                .status(TransactionStatus.PROCESSING)
+                .description("DLQ integration test")
+                .idempotencyKey(UUID.randomUUID().toString())
+                .retryCount(0)
+                .createdAt(Instant.now())
+                .updatedAt(Instant.now())
+                .build();
+
+        eventPublisher.publish(tx, TransactionEventType.PROCESSING);
+
+        // FixedBackOff(1000L, 2L) = 2 retries, ~3 s total before recoverer is called.
+        // Allow 20 s for the full retry cycle + DB write.
+        await().atMost(20, SECONDS).untilAsserted(() -> {
+            List<DeadLetterEventJpaEntity> dlqEntries = deadLetterEventJpaRepository.findAll()
+                    .stream()
+                    .filter(e -> "SIMULATED_FAILURE_FOR_DLQ_TEST".equals(e.getErrorMessage()))
+                    .toList();
+            assertThat(dlqEntries).isNotEmpty();
+        });
+
+        // Verify the persisted entry contains the expected fields
+        DeadLetterEventJpaEntity dlqEntry = deadLetterEventJpaRepository.findAll()
+                .stream()
+                .filter(e -> "SIMULATED_FAILURE_FOR_DLQ_TEST".equals(e.getErrorMessage()))
+                .findFirst()
+                .orElseThrow();
+
+        assertThat(dlqEntry.getTopic()).isNotBlank();
+        assertThat(dlqEntry.getPayload()).contains(txId.toString());
+        assertThat(dlqEntry.getPayload()).contains("PROCESSING");
+        assertThat(dlqEntry.getCreatedAt()).isNotNull();
+        assertThat(dlqEntry.getResolvedAt()).isNull();
+    }
+
+    // ── Inner test configuration: consumer that always throws ─────────────────
+
+    /**
+     * Registers an additional Kafka listener in group {@code test-always-fail-group}.
+     * Every received message triggers the global {@code kafkaErrorHandler}, which retries
+     * twice then routes the record to the {@code PersistingDlqRecoverer} in {@link KafkaConfig}.
+     */
+    @TestConfiguration
+    static class AlwaysFailConsumerConfig {
+
+        @KafkaListener(
+                topics = "${app.kafka.topics.transaction-events}",
+                groupId = "test-always-fail-group"
+        )
+        public void failingConsumer(TransactionEventMessage event) {
+            throw new RuntimeException("SIMULATED_FAILURE_FOR_DLQ_TEST");
+        }
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private String registerAndGetToken(String username, String email) throws Exception {
+        MvcResult result = mockMvc.perform(post("/api/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                new RegisterRequest(username, email, "password123"))))
+                .andExpect(status().isCreated())
+                .andReturn();
+        return objectMapper.readTree(result.getResponse().getContentAsString()).get("token").asText();
+    }
+
+    private UUID extractUserId(String token) throws Exception {
+        MvcResult result = mockMvc.perform(get("/api/users/me")
+                        .header("Authorization", "Bearer " + token))
+                .andReturn();
+        return UUID.fromString(
+                objectMapper.readTree(result.getResponse().getContentAsString()).get("id").asText());
+    }
+}

--- a/backend/src/test/java/dev/cuong/payment/presentation/admin/AdminControllerTest.java
+++ b/backend/src/test/java/dev/cuong/payment/presentation/admin/AdminControllerTest.java
@@ -1,0 +1,276 @@
+package dev.cuong.payment.presentation.admin;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.cuong.payment.application.port.out.AccountRepository;
+import dev.cuong.payment.domain.model.Account;
+import dev.cuong.payment.domain.vo.UserRole;
+import dev.cuong.payment.infrastructure.persistence.entity.DeadLetterEventJpaEntity;
+import dev.cuong.payment.infrastructure.persistence.entity.UserJpaEntity;
+import dev.cuong.payment.infrastructure.persistence.repository.DeadLetterEventJpaRepository;
+import dev.cuong.payment.infrastructure.persistence.repository.UserJpaRepository;
+import dev.cuong.payment.presentation.auth.LoginRequest;
+import dev.cuong.payment.presentation.auth.RegisterRequest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.transaction.annotation.Transactional;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Integration tests for {@link AdminController}.
+ *
+ * <p>Uses real Postgres. Kafka and Redis are excluded — the admin service does not need
+ * Kafka to list/retry DLQ events (retry re-publishes via the no-op {@code EventPublisher}).
+ *
+ * <p>Admin users are created by registering a normal user and then updating the role
+ * directly via {@link UserJpaRepository}. The user re-authenticates to receive a JWT
+ * that carries the {@code ROLE_ADMIN} authority.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@Testcontainers
+@Transactional
+@TestPropertySource(properties = {
+        "spring.autoconfigure.exclude=" +
+                "org.redisson.spring.starter.RedissonAutoConfigurationV2," +
+                "org.springframework.boot.autoconfigure.kafka.KafkaAutoConfiguration",
+        "spring.flyway.enabled=true",
+        "app.jwt.secret=test-secret-key-minimum-32-chars-for-hs256!"
+})
+class AdminControllerTest {
+
+    @Container
+    @ServiceConnection
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:15-alpine");
+
+    @Autowired MockMvc mockMvc;
+    @Autowired ObjectMapper objectMapper;
+    @Autowired UserJpaRepository userJpaRepository;
+    @Autowired DeadLetterEventJpaRepository deadLetterEventJpaRepository;
+    @Autowired AccountRepository accountRepository;
+
+    // ── DLQ endpoint ──────────────────────────────────────────────────────────
+
+    @Test
+    void should_return_empty_dlq_list_when_no_events_exist() throws Exception {
+        String adminToken = createAdminAndGetToken("adm1", "adm1@test.com", "password");
+
+        mockMvc.perform(get("/api/admin/dlq")
+                        .header("Authorization", "Bearer " + adminToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data").isArray())
+                .andExpect(jsonPath("$.totalElements").value(0));
+    }
+
+    @Test
+    void should_return_dlq_event_when_entry_is_seeded() throws Exception {
+        String adminToken = createAdminAndGetToken("adm2", "adm2@test.com", "password");
+
+        DeadLetterEventJpaEntity entry = DeadLetterEventJpaEntity.builder()
+                .topic("payment.transaction.events")
+                .kafkaPartition(0)
+                .kafkaOffset(42L)
+                .payload("{\"transactionId\":\"" + UUID.randomUUID() + "\",\"eventType\":\"PROCESSING\"}")
+                .errorMessage("Simulated consumer failure")
+                .build();
+        deadLetterEventJpaRepository.saveAndFlush(entry);
+
+        mockMvc.perform(get("/api/admin/dlq")
+                        .header("Authorization", "Bearer " + adminToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.totalElements").value(1))
+                .andExpect(jsonPath("$.data[0].topic").value("payment.transaction.events"))
+                .andExpect(jsonPath("$.data[0].errorMessage").value("Simulated consumer failure"));
+    }
+
+    // ── DLQ retry endpoint ────────────────────────────────────────────────────
+
+    @Test
+    void should_return_404_when_retry_dlq_event_id_does_not_exist() throws Exception {
+        String adminToken = createAdminAndGetToken("adm3", "adm3@test.com", "password");
+
+        mockMvc.perform(post("/api/admin/dlq/" + UUID.randomUUID() + "/retry")
+                        .header("Authorization", "Bearer " + adminToken))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("NOT_FOUND"));
+    }
+
+    @Test
+    void should_return_204_and_mark_resolved_when_retry_succeeds() throws Exception {
+        String adminToken = createAdminAndGetToken("adm4", "adm4@test.com", "password");
+
+        // Create a sender with funded account and a receiver
+        String senderToken   = registerAndGetToken("tx-sender", "sender@test.com", "password");
+        String receiverToken = registerAndGetToken("tx-recv",   "recv@test.com",   "password");
+        UUID senderUserId    = extractUserId(senderToken);
+        UUID toAccountId     = accountRepository.findByUserId(extractUserId(receiverToken)).orElseThrow().getId();
+
+        fundAccount(senderUserId, new BigDecimal("500.00"));
+
+        // Create a transaction to get a real transactionId
+        MvcResult txResult = mockMvc.perform(post("/api/transactions")
+                        .header("Authorization", "Bearer " + senderToken)
+                        .header("Idempotency-Key", UUID.randomUUID().toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(txBody(toAccountId, "100.00")))
+                .andExpect(status().isCreated())
+                .andReturn();
+        String transactionId = objectMapper.readTree(txResult.getResponse().getContentAsString())
+                .get("id").asText();
+
+        // Seed a DLQ event pointing to that transaction
+        String payload = String.format(
+                "{\"transactionId\":\"%s\",\"eventType\":\"PROCESSING\",\"fromAccountId\":\"%s\"," +
+                "\"toAccountId\":\"%s\",\"amount\":100.00,\"currency\":\"USD\",\"status\":\"PROCESSING\"," +
+                "\"retryCount\":0,\"occurredAt\":\"2024-01-01T00:00:00Z\"}",
+                transactionId, senderUserId, toAccountId);
+
+        DeadLetterEventJpaEntity dlqEntry = DeadLetterEventJpaEntity.builder()
+                .topic("payment.transaction.events")
+                .kafkaPartition(0)
+                .kafkaOffset(100L)
+                .payload(payload)
+                .errorMessage("Simulated consumer failure for retry test")
+                .build();
+        deadLetterEventJpaRepository.saveAndFlush(dlqEntry);
+        UUID dlqId = dlqEntry.getId();
+
+        // Retry the DLQ event
+        mockMvc.perform(post("/api/admin/dlq/" + dlqId + "/retry")
+                        .header("Authorization", "Bearer " + adminToken))
+                .andExpect(status().isNoContent());
+
+        // Verify the event is marked resolved
+        DeadLetterEventJpaEntity resolved = deadLetterEventJpaRepository.findById(dlqId).orElseThrow();
+        assertThat(resolved.getResolvedAt()).isNotNull();
+        assertThat(resolved.getResolvedBy()).isEqualTo("admin-retry");
+    }
+
+    // ── Transactions endpoint ─────────────────────────────────────────────────
+
+    @Test
+    void should_return_all_transactions_across_users_when_admin() throws Exception {
+        String adminToken    = createAdminAndGetToken("adm5", "adm5@test.com", "password");
+        String senderToken   = registerAndGetToken("tx-s2", "txs2@test.com", "password");
+        String receiverToken = registerAndGetToken("tx-r2", "txr2@test.com", "password");
+        UUID senderUserId    = extractUserId(senderToken);
+        UUID toAccountId     = accountRepository.findByUserId(extractUserId(receiverToken)).orElseThrow().getId();
+
+        fundAccount(senderUserId, new BigDecimal("500.00"));
+
+        mockMvc.perform(post("/api/transactions")
+                        .header("Authorization", "Bearer " + senderToken)
+                        .header("Idempotency-Key", UUID.randomUUID().toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(txBody(toAccountId, "50.00")))
+                .andExpect(status().isCreated());
+
+        mockMvc.perform(get("/api/admin/transactions")
+                        .header("Authorization", "Bearer " + adminToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.totalElements").value(1))
+                .andExpect(jsonPath("$.data[0].status").value("PENDING"));
+    }
+
+    // ── Circuit breaker endpoint ──────────────────────────────────────────────
+
+    @Test
+    void should_return_circuit_breaker_status_when_admin() throws Exception {
+        String adminToken = createAdminAndGetToken("adm6", "adm6@test.com", "password");
+
+        mockMvc.perform(get("/api/admin/circuit-breaker")
+                        .header("Authorization", "Bearer " + adminToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name").value("payment-gateway"))
+                .andExpect(jsonPath("$.state").isNotEmpty());
+    }
+
+    // ── Authorization ─────────────────────────────────────────────────────────
+
+    @Test
+    void should_return_403_when_regular_user_calls_admin_endpoint() throws Exception {
+        String userToken = registerAndGetToken("regular", "regular@test.com", "password");
+
+        mockMvc.perform(get("/api/admin/dlq")
+                        .header("Authorization", "Bearer " + userToken))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void should_return_401_when_no_jwt_on_admin_endpoint() throws Exception {
+        mockMvc.perform(get("/api/admin/dlq"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private String createAdminAndGetToken(String username, String email, String password) throws Exception {
+        String token = registerAndGetToken(username, email, password);
+        UUID userId = extractUserId(token);
+
+        // Promote the user to ADMIN within the test transaction so MockMvc calls see the update
+        UserJpaEntity user = userJpaRepository.findById(userId).orElseThrow();
+        user.setRole(UserRole.ADMIN);
+        userJpaRepository.saveAndFlush(user);
+
+        // Re-login to get a JWT that carries ROLE_ADMIN
+        return login(username, password);
+    }
+
+    private String registerAndGetToken(String username, String email, String password) throws Exception {
+        MvcResult result = mockMvc.perform(post("/api/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                new RegisterRequest(username, email, password))))
+                .andExpect(status().isCreated())
+                .andReturn();
+        return objectMapper.readTree(result.getResponse().getContentAsString()).get("token").asText();
+    }
+
+    private String login(String username, String password) throws Exception {
+        MvcResult result = mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new LoginRequest(username, password))))
+                .andExpect(status().isOk())
+                .andReturn();
+        return objectMapper.readTree(result.getResponse().getContentAsString()).get("token").asText();
+    }
+
+    private UUID extractUserId(String token) throws Exception {
+        MvcResult result = mockMvc.perform(get("/api/users/me")
+                        .header("Authorization", "Bearer " + token))
+                .andReturn();
+        return UUID.fromString(
+                objectMapper.readTree(result.getResponse().getContentAsString()).get("id").asText());
+    }
+
+    private void fundAccount(UUID userId, BigDecimal amount) {
+        Account account = accountRepository.findByUserId(userId).orElseThrow();
+        account.credit(amount);
+        accountRepository.save(account);
+    }
+
+    private String txBody(UUID toAccountId, String amount) throws Exception {
+        var node = objectMapper.createObjectNode();
+        node.put("toAccountId", toAccountId.toString());
+        node.put("amount", new BigDecimal(amount));
+        return objectMapper.writeValueAsString(node);
+    }
+}


### PR DESCRIPTION
## What this PR does
Closes #16 

Implements the Dead Letter Queue pipeline and the Admin API. Kafka consumer
failures now survive retry exhaustion: the failed record is persisted to
`dead_letter_events` (DB-first for visibility even if Kafka is down), then
forwarded to the DLQ Kafka topic. Admins can list DLQ events, retry them
(re-publishes via the normal EventPublisher path), view all transactions
across all users, and check the payment-gateway circuit breaker state - all
behind `@PreAuthorize("hasRole('ADMIN')")`.

## How to test

1. Start all infrastructure: `docker compose up -d`
2. Run the full test suite: `./gradlew test`
   - AdminControllerTest: verifies 200/403/401 responses
   - DlqIntegrationTest: end-to-end - publishes an event, always-fail
     consumer exhausts retries, Awaitility confirms DB row appears
3. Manual smoke test (with a running app):
   - Register a user, update role to ADMIN in DB, login to get JWT
   - `GET  /api/admin/dlq` → paginated DLQ events (empty initially)
   - `GET  /api/admin/transactions` → all transactions across all users
   - `GET  /api/admin/circuit-breaker` → payment-gateway CB state + metrics
   - Force a consumer failure by publishing to a topic with a bad consumer,
     then `POST /api/admin/dlq/{id}/retry` to re-publish

## Technical decisions

**DB-first, swallow Kafka DLQ publish failure**: `PersistingDlqRecoverer`
writes to Postgres before calling `DeadLetterPublishingRecoverer`. If the
Kafka publish throws, the exception is caught and logged - NOT propagated.
Spring Kafka must see recovery as successful to commit the offset; if it
sees a failure it retries forever, making the DLQ mechanism counterproductive.

**Retry via re-publish, not raw bytes**: `retryDlqEvent` loads the
Transaction from DB and calls `eventPublisher.publish(tx, eventType)` -
the same path as normal event publishing. This avoids a separate raw-byte
`KafkaTemplate` and stays within hexagonal boundaries.

**Root cause extraction**: `exception.getMessage()` on the exception
received by the recoverer returns the Spring Kafka wrapper message
(`ListenerExecutionFailedException: Listener method threw exception`), not
the real error. `rootCauseMessage()` walks `getCause()` to the root so the
stored `error_message` is always the meaningful original exception text.

**AccessDeniedException explicit handler**: Method-level `@PreAuthorize`
throws inside the controller proxy AFTER Spring's ExceptionTranslationFilter
has already passed. The catch-all `@ExceptionHandler(Exception.class)` was
intercepting it and returning 500. Explicit handler returns 403.