### PR TITLE
Task/15 prometheus metrics

### DIFF
--- a/backend/bin/main/application.yml
+++ b/backend/bin/main/application.yml
@@ -76,6 +76,12 @@ management:
   metrics:
     tags:
       application: ${spring.application.name}
+    distribution:
+      # Emit native Prometheus histogram buckets — required for histogram_quantile() in Grafana
+      percentiles-histogram:
+        transactions.processing.duration: true
+      percentiles:
+        transactions.processing.duration: 0.5, 0.95, 0.99
   prometheus:
     metrics:
       export:

--- a/backend/src/main/java/dev/cuong/payment/application/port/out/TransactionMetricsPort.java
+++ b/backend/src/main/java/dev/cuong/payment/application/port/out/TransactionMetricsPort.java
@@ -1,0 +1,31 @@
+package dev.cuong.payment.application.port.out;
+
+import java.time.Duration;
+
+/**
+ * Outbound port for emitting business metrics about transaction processing.
+ *
+ * <p>The application layer depends on this port — not on Micrometer or any specific
+ * monitoring SDK — so the metrics backend can be swapped (Prometheus, OpenTelemetry,
+ * Datadog, …) without touching business code.
+ *
+ * <p>Built-in HTTP/JVM/DB metrics are auto-instrumented by Spring Boot Actuator and
+ * are not represented here. This port is for <em>business</em> meters only.
+ */
+public interface TransactionMetricsPort {
+
+    /**
+     * Increments the {@code transactions.created.total} counter.
+     * Called once per successful transaction creation in the API path.
+     */
+    void recordCreated();
+
+    /**
+     * Records the outcome of a processed transaction, both as a counter increment
+     * (tagged by {@code status}) and as a duration sample on the latency histogram.
+     *
+     * @param finalStatus terminal status name: {@code SUCCESS}, {@code FAILED}, or {@code TIMEOUT}
+     * @param duration    wall-clock processing time from PENDING→terminal
+     */
+    void recordProcessed(String finalStatus, Duration duration);
+}

--- a/backend/src/main/java/dev/cuong/payment/application/service/TransactionApplicationService.java
+++ b/backend/src/main/java/dev/cuong/payment/application/service/TransactionApplicationService.java
@@ -8,6 +8,7 @@ import dev.cuong.payment.application.port.in.GetTransactionUseCase;
 import dev.cuong.payment.application.port.in.RefundTransactionUseCase;
 import dev.cuong.payment.application.port.out.AccountRepository;
 import dev.cuong.payment.application.port.out.EventPublisher;
+import dev.cuong.payment.application.port.out.TransactionMetricsPort;
 import dev.cuong.payment.application.port.out.TransactionRepository;
 import dev.cuong.payment.domain.event.TransactionEventType;
 import dev.cuong.payment.domain.exception.AccountNotFoundException;
@@ -34,6 +35,7 @@ public class TransactionApplicationService implements CreateTransactionUseCase, 
     private final TransactionRepository transactionRepository;
     private final AccountRepository accountRepository;
     private final EventPublisher eventPublisher;
+    private final TransactionMetricsPort metrics;
 
     @Override
     @Transactional
@@ -84,6 +86,7 @@ public class TransactionApplicationService implements CreateTransactionUseCase, 
                 saved.getId(), fromAccount.getId(), toAccount.getId(), command.amount());
 
         eventPublisher.publish(saved, TransactionEventType.CREATED);
+        metrics.recordCreated();
 
         return toResult(saved);
     }

--- a/backend/src/main/java/dev/cuong/payment/infrastructure/config/SecurityConfig.java
+++ b/backend/src/main/java/dev/cuong/payment/infrastructure/config/SecurityConfig.java
@@ -35,7 +35,7 @@ public class SecurityConfig {
                 .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/api/auth/**").permitAll()
-                        .requestMatchers("/actuator/health", "/actuator/info").permitAll()
+                        .requestMatchers("/actuator/health", "/actuator/info", "/actuator/prometheus").permitAll()
                         .anyRequest().authenticated()
                 )
                 .exceptionHandling(ex -> ex

--- a/backend/src/main/java/dev/cuong/payment/infrastructure/kafka/TransactionProcessingConsumer.java
+++ b/backend/src/main/java/dev/cuong/payment/infrastructure/kafka/TransactionProcessingConsumer.java
@@ -4,6 +4,7 @@ import dev.cuong.payment.application.port.out.AccountRepository;
 import dev.cuong.payment.application.port.out.DistributedLockPort;
 import dev.cuong.payment.application.port.out.EventPublisher;
 import dev.cuong.payment.application.port.out.PaymentGatewayPort;
+import dev.cuong.payment.application.port.out.TransactionMetricsPort;
 import dev.cuong.payment.application.port.out.TransactionRepository;
 import dev.cuong.payment.domain.event.TransactionEventType;
 import dev.cuong.payment.domain.exception.PaymentGatewayException;
@@ -23,6 +24,8 @@ import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.support.TransactionTemplate;
 
 import java.math.BigDecimal;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.UUID;
 
 /**
@@ -58,6 +61,7 @@ public class TransactionProcessingConsumer {
     private final PaymentGatewayPort paymentGateway;
     private final DistributedLockPort distributedLock;
     private final EventPublisher eventPublisher;
+    private final TransactionMetricsPort metrics;
     private final PlatformTransactionManager transactionManager;
 
     // TransactionTemplate is derived from transactionManager — not a Spring bean itself.
@@ -124,25 +128,35 @@ public class TransactionProcessingConsumer {
         // ── Phase 2: Gateway call + finalisation ──────────────────────────────
         // Runs OUTSIDE any DB transaction — the gateway call is an IO operation
         // and should not hold a DB connection open for its duration.
+        // Timer starts after Phase 1 so we measure gateway+finalisation latency,
+        // not DB-only "still PENDING" overhead.
+        Instant start = Instant.now();
+        TransactionStatus terminalStatus;
         try {
             String gatewayRef = paymentGateway.charge(tx.getId(), tx.getAmount());
             finaliseSuccess(tx.getId(), tx.getToAccountId(), tx.getAmount(), gatewayRef);
+            terminalStatus = TransactionStatus.SUCCESS;
 
         } catch (PaymentGatewayTimeoutException e) {
             log.warn("Gateway timeout after retries — marking TIMEOUT: transactionId={}", transactionId);
             finaliseFailure(tx.getId(), tx.getFromAccountId(), tx.getAmount(), TransactionStatus.TIMEOUT,
                     "Gateway timeout after retries");
+            terminalStatus = TransactionStatus.TIMEOUT;
 
         } catch (PaymentGatewayException e) {
             log.warn("Gateway rejected payment — marking FAILED: transactionId={}, reason={}", transactionId, e.getMessage());
             finaliseFailure(tx.getId(), tx.getFromAccountId(), tx.getAmount(), TransactionStatus.FAILED,
                     e.getMessage());
+            terminalStatus = TransactionStatus.FAILED;
 
         } catch (CallNotPermittedException e) {
             log.error("Circuit breaker OPEN — marking FAILED: transactionId={}", transactionId);
             finaliseFailure(tx.getId(), tx.getFromAccountId(), tx.getAmount(), TransactionStatus.FAILED,
                     "Payment gateway unavailable (circuit breaker open)");
+            terminalStatus = TransactionStatus.FAILED;
         }
+
+        metrics.recordProcessed(terminalStatus.name(), Duration.between(start, Instant.now()));
     }
 
     private void finaliseSuccess(UUID transactionId, UUID toAccountId, BigDecimal amount, String gatewayRef) {

--- a/backend/src/main/java/dev/cuong/payment/infrastructure/metrics/MicrometerTransactionMetrics.java
+++ b/backend/src/main/java/dev/cuong/payment/infrastructure/metrics/MicrometerTransactionMetrics.java
@@ -1,0 +1,73 @@
+package dev.cuong.payment.infrastructure.metrics;
+
+import dev.cuong.payment.application.port.out.TransactionMetricsPort;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * Micrometer-backed implementation of {@link TransactionMetricsPort}.
+ *
+ * <p>Meters exposed at {@code /actuator/prometheus}:
+ * <ul>
+ *   <li>{@code transactions_created_total} — counter, no tags
+ *   <li>{@code transactions_processed_total{status="SUCCESS|FAILED|TIMEOUT"}} — counter
+ *   <li>{@code transactions_processing_duration_seconds} — timer (with P50/P95/P99 histogram)
+ * </ul>
+ *
+ * <p>Per-status counters are cached in a {@link ConcurrentMap} so we register each
+ * meter exactly once with the registry — registering on every call would create a
+ * new meter object per invocation (Micrometer deduplicates internally, but caching
+ * skips the lookup overhead on the hot path).
+ */
+@Component
+public class MicrometerTransactionMetrics implements TransactionMetricsPort {
+
+    private static final String CREATED_COUNTER = "transactions.created";
+    private static final String PROCESSED_COUNTER = "transactions.processed";
+    private static final String PROCESSING_TIMER = "transactions.processing.duration";
+
+    private final MeterRegistry registry;
+    private final Counter createdCounter;
+    private final Timer processingTimer;
+    private final ConcurrentMap<String, Counter> processedCountersByStatus = new ConcurrentHashMap<>();
+
+    public MicrometerTransactionMetrics(MeterRegistry registry) {
+        this.registry = registry;
+
+        this.createdCounter = Counter.builder(CREATED_COUNTER)
+                .description("Total transactions created via the API")
+                .register(registry);
+
+        this.processingTimer = Timer.builder(PROCESSING_TIMER)
+                .description("End-to-end processing duration: PENDING → terminal status")
+                .publishPercentileHistogram()
+                .publishPercentiles(0.5, 0.95, 0.99)
+                .register(registry);
+    }
+
+    @Override
+    public void recordCreated() {
+        createdCounter.increment();
+    }
+
+    @Override
+    public void recordProcessed(String finalStatus, Duration duration) {
+        processedCountersByStatus
+                .computeIfAbsent(finalStatus, this::buildProcessedCounter)
+                .increment();
+        processingTimer.record(duration);
+    }
+
+    private Counter buildProcessedCounter(String status) {
+        return Counter.builder(PROCESSED_COUNTER)
+                .description("Total transactions processed, tagged by terminal status")
+                .tag("status", status)
+                .register(registry);
+    }
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -76,6 +76,12 @@ management:
   metrics:
     tags:
       application: ${spring.application.name}
+    distribution:
+      # Emit native Prometheus histogram buckets — required for histogram_quantile() in Grafana
+      percentiles-histogram:
+        transactions.processing.duration: true
+      percentiles:
+        transactions.processing.duration: 0.5, 0.95, 0.99
   prometheus:
     metrics:
       export:

--- a/backend/src/test/java/dev/cuong/payment/infrastructure/metrics/PrometheusEndpointTest.java
+++ b/backend/src/test/java/dev/cuong/payment/infrastructure/metrics/PrometheusEndpointTest.java
@@ -1,0 +1,88 @@
+package dev.cuong.payment.infrastructure.metrics;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Verifies the Prometheus scrape endpoint exposes our custom business metrics.
+ *
+ * <p>Three metric families MUST be present immediately on startup (no traffic required):
+ * <ul>
+ *   <li>{@code transactions_created_total} — registered by {@link MicrometerTransactionMetrics}
+ *   <li>{@code transactions_processing_duration_seconds_count} — registered by the same component
+ *   <li>{@code resilience4j_circuitbreaker_state{name="payment-gateway"}} — auto-registered by
+ *       {@code resilience4j-spring-boot3} when Micrometer is on the classpath
+ * </ul>
+ *
+ * <p>Per-status processed counters ({@code transactions_processed_total{status="..."}}) appear
+ * lazily on first increment — they are NOT asserted here.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@Testcontainers
+@TestPropertySource(properties = {
+        "spring.autoconfigure.exclude=" +
+                "org.redisson.spring.starter.RedissonAutoConfigurationV2," +
+                "org.springframework.boot.autoconfigure.kafka.KafkaAutoConfiguration",
+        "spring.flyway.enabled=true",
+        "spring.jpa.hibernate.ddl-auto=validate"
+})
+class PrometheusEndpointTest {
+
+    static final PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:15-alpine");
+
+    static {
+        postgres.start();
+    }
+
+    @DynamicPropertySource
+    static void overrideProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", postgres::getJdbcUrl);
+        registry.add("spring.datasource.username", postgres::getUsername);
+        registry.add("spring.datasource.password", postgres::getPassword);
+    }
+
+    @Autowired MockMvc mockMvc;
+
+    @Test
+    void should_expose_custom_business_metrics_at_prometheus_endpoint() throws Exception {
+        MvcResult result = mockMvc.perform(get("/actuator/prometheus"))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        String body = result.getResponse().getContentAsString();
+
+        assertThat(body)
+                .as("transactions.created counter must be exposed")
+                .contains("transactions_created_total");
+
+        assertThat(body)
+                .as("transactions.processing.duration timer must be exposed (count series)")
+                .contains("transactions_processing_duration_seconds_count");
+
+        assertThat(body)
+                .as("resilience4j circuit breaker state gauge must be auto-registered for payment-gateway")
+                .contains("resilience4j_circuitbreaker_state")
+                .contains("name=\"payment-gateway\"");
+    }
+
+    @Test
+    void should_be_publicly_accessible_without_authentication() throws Exception {
+        // Prometheus scrapers must reach this endpoint without a JWT.
+        mockMvc.perform(get("/actuator/prometheus"))
+                .andExpect(status().isOk());
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -143,7 +143,7 @@ services:
       GF_SECURITY_ADMIN_USER: admin
       GF_SECURITY_ADMIN_PASSWORD: admin
       GF_USERS_ALLOW_SIGN_UP: 'false'
-      GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH: /var/lib/grafana/dashboards/payment-service.json
+      GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH: /etc/grafana/provisioning/dashboards/payment-service.json
     volumes:
       - grafana_data:/var/lib/grafana
       # Dashboard auto-provisioning (JSON file added in Task 15)

--- a/monitoring/grafana/provisioning/dashboards/payment-service.json
+++ b/monitoring/grafana/provisioning/dashboards/payment-service.json
@@ -1,0 +1,237 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Transactions created per minute via the API.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "never"
+          },
+          "unit": "tps"
+        }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "id": 1,
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "single" }
+      },
+      "targets": [
+        {
+          "expr": "rate(transactions_created_total[1m]) * 60",
+          "legendFormat": "created/min",
+          "refId": "A"
+        }
+      ],
+      "title": "Transaction Throughput",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Percentage of processed transactions that failed or timed out, over the last 5 minutes.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 1 },
+              { "color": "red", "value": 5 }
+            ]
+          },
+          "unit": "percent"
+        }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "id": 2,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "targets": [
+        {
+          "expr": "(sum(rate(transactions_processed_total{status=~\"FAILED|TIMEOUT\"}[5m])) / sum(rate(transactions_processed_total[5m]))) * 100",
+          "legendFormat": "error %",
+          "refId": "A"
+        }
+      ],
+      "title": "Error Rate (5m)",
+      "type": "gauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "P50/P95/P99 of end-to-end transaction processing duration (PROCESSING → terminal status).",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 5,
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "never"
+          },
+          "unit": "s"
+        }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "id": 3,
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "multi" }
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, sum(rate(transactions_processing_duration_seconds_bucket[5m])) by (le))",
+          "legendFormat": "P50",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(transactions_processing_duration_seconds_bucket[5m])) by (le))",
+          "legendFormat": "P95",
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum(rate(transactions_processing_duration_seconds_bucket[5m])) by (le))",
+          "legendFormat": "P99",
+          "refId": "C"
+        }
+      ],
+      "title": "Processing Latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Resilience4j payment-gateway circuit breaker. 0 = CLOSED, 1 = OPEN, 2 = HALF_OPEN.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [
+            { "options": { "0": { "color": "green",  "text": "CLOSED" } }, "type": "value" },
+            { "options": { "1": { "color": "red",    "text": "OPEN" } },   "type": "value" },
+            { "options": { "2": { "color": "yellow", "text": "HALF_OPEN" } }, "type": "value" }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green",  "value": null },
+              { "color": "yellow", "value": 2 },
+              { "color": "red",    "value": 1 }
+            ]
+          }
+        }
+      },
+      "gridPos": { "h": 8, "w": 6, "x": 12, "y": 8 },
+      "id": 4,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        }
+      },
+      "targets": [
+        {
+          "expr": "max(resilience4j_circuitbreaker_state{name=\"payment-gateway\"} * on(state) group_left() (label_replace(vector(0),\"state\",\"closed\",\"\",\"\") or label_replace(vector(1),\"state\",\"open\",\"\",\"\") or label_replace(vector(2),\"state\",\"half_open\",\"\",\"\")))",
+          "instant": false,
+          "legendFormat": "state",
+          "refId": "A"
+        }
+      ],
+      "title": "Circuit Breaker (payment-gateway)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "HTTP 429 responses per minute. With this app, 429 is only ever the rate-limit denial.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green",  "value": null },
+              { "color": "yellow", "value": 1 },
+              { "color": "red",    "value": 10 }
+            ]
+          },
+          "unit": "rpm"
+        }
+      },
+      "gridPos": { "h": 8, "w": 6, "x": 18, "y": 8 },
+      "id": 5,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(http_server_requests_seconds_count{status=\"429\"}[1m])) * 60",
+          "legendFormat": "rate-limit hits/min",
+          "refId": "A"
+        }
+      ],
+      "title": "Rate Limit Hits",
+      "type": "stat"
+    }
+  ],
+  "refresh": "5s",
+  "schemaVersion": 39,
+  "tags": ["payment", "fintech"],
+  "templating": { "list": [] },
+  "time": { "from": "now-15m", "to": "now" },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Payment Service",
+  "uid": "payment-service",
+  "version": 1,
+  "weekStart": ""
+}


### PR DESCRIPTION
## What this PR does
Closes #17 

Adds business-level Prometheus metrics on top of Spring Boot Actuator's
built-in HTTP/JVM/DB instrumentation, and provisions a Grafana dashboard
that auto-loads as the home page. The application layer talks to a
TransactionMetricsPort interface; a MicrometerTransactionMetrics adapter
in infrastructure/ holds all framework coupling - so the metrics backend
can be swapped (OpenTelemetry, Datadog, …) without touching business code.

## How to test

1. `docker compose up -d` - brings up Postgres, Redis, Kafka, Prometheus, Grafana
2. From `backend/`: `.\gradlew.bat bootRun --args='--spring.profiles.active=local'`
3. **Endpoint**: `curl http://localhost:8080/actuator/prometheus` should
   contain `transactions_created_total`, `transactions_processing_duration_seconds_count`,
   and `resilience4j_circuitbreaker_state{name="payment-gateway"}`
4. **Prometheus scraping**: http://localhost:9090/targets - `payment-service`
   job should be UP (scrape interval 15s)
5. **Grafana**: http://localhost:3001 (admin / admin) - "Payment Service"
   dashboard auto-loads. Register a user, create a few transactions to
   populate the throughput / latency panels.
6. **Test suite**: `.\gradlew.bat test` - full suite green; the new
   `PrometheusEndpointTest` is the targeted assertion.

## Technical decisions

**Port + adapter for metrics, not direct Micrometer use in services**:
Application services depend on TransactionMetricsPort. The Micrometer
adapter sits in infrastructure/. Keeps the application layer pure and
matches the existing hexagonal pattern (TransactionRepository,
DistributedLockPort, etc.).

**Timer wraps the gateway+finalisation phase only, not Phase 1
(PENDING→PROCESSING)**: Phase 1 is just a DB write and dominated by HTTP
latency that's already instrumented by Actuator. Including it would
distort the gateway-call P95 we actually care about.

**No custom rate-limit metric**: 429 responses are auto-tracked by
Actuator's `http_server_requests_seconds_count{status="429"}`. Rate
limiting is the only source of 429 in this app, so the dashboard query
is unambiguous and we avoid duplicate instrumentation.

**Circuit breaker state - zero custom code**: resilience4j-spring-boot3
auto-registers `resilience4j_circuitbreaker_state` when Micrometer is on
the classpath. Adding a custom gauge would just shadow it.

**/actuator/prometheus on permitAll**: Prometheus scrapers can't carry a
JWT. In production this should be reachable only over a private network
or behind a separate management port - out of scope for this task.