### PR TITLE
Task/16 structured logging

### DIFF
--- a/backend/bin/main/application.yml
+++ b/backend/bin/main/application.yml
@@ -136,9 +136,6 @@ resilience4j:
           - dev.cuong.payment.domain.exception.PaymentGatewayException
 
 # ── Logging ─────────────────────────────────────────────────────────────────────
-logging:
-  level:
-    dev.cuong.payment: INFO
-    org.springframework.security: WARN
-    org.hibernate.SQL: WARN
-    org.apache.kafka: WARN
+# Logger levels and encoder format are configured in logback-spring.xml so that
+# JSON encoding (production) vs human-readable encoding (local profile) can be
+# switched per Spring profile in one place.

--- a/backend/bin/main/logback-spring.xml
+++ b/backend/bin/main/logback-spring.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Logging configuration:
+
+  - Default (no profile or any profile other than "local"): one JSON object per line
+    via LogstashEncoder. Suitable for production aggregation (Loki / ELK / Splunk).
+  - "local" profile: human-readable colored pattern with MDC fields appended.
+
+  MDC keys are whitelisted explicitly so stale entries (e.g. from a forgotten
+  MDC.put without a matching MDC.remove) cannot pollute production output.
+-->
+<configuration>
+
+    <springProfile name="local">
+        <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+            <encoder>
+                <pattern>%d{HH:mm:ss.SSS} %highlight(%-5level) [%thread] %cyan(%logger{36}) [traceId=%X{traceId:-} userId=%X{userId:-} txId=%X{transactionId:-}] - %msg%n</pattern>
+            </encoder>
+        </appender>
+
+        <root level="INFO">
+            <appender-ref ref="CONSOLE"/>
+        </root>
+
+        <logger name="dev.cuong.payment" level="INFO"/>
+        <logger name="org.springframework.security" level="WARN"/>
+        <logger name="org.hibernate.SQL" level="WARN"/>
+        <logger name="org.apache.kafka" level="WARN"/>
+    </springProfile>
+
+    <springProfile name="!local">
+        <appender name="JSON" class="ch.qos.logback.core.ConsoleAppender">
+            <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+                <fieldNames>
+                    <timestamp>timestamp</timestamp>
+                    <message>message</message>
+                    <logger>logger</logger>
+                    <thread>thread</thread>
+                    <level>level</level>
+                    <levelValue>[ignore]</levelValue>
+                    <version>[ignore]</version>
+                </fieldNames>
+                <!--
+                  Whitelist: only these MDC keys appear in JSON output. Anything else
+                  in MDC (Spring/Kafka internal keys, accidentally-leaked entries) is
+                  ignored, keeping the schema stable.
+                -->
+                <includeMdcKeyName>traceId</includeMdcKeyName>
+                <includeMdcKeyName>userId</includeMdcKeyName>
+                <includeMdcKeyName>transactionId</includeMdcKeyName>
+            </encoder>
+        </appender>
+
+        <root level="INFO">
+            <appender-ref ref="JSON"/>
+        </root>
+
+        <logger name="dev.cuong.payment" level="INFO"/>
+        <logger name="org.springframework.security" level="WARN"/>
+        <logger name="org.hibernate.SQL" level="WARN"/>
+        <logger name="org.apache.kafka" level="WARN"/>
+    </springProfile>
+
+</configuration>

--- a/backend/src/main/java/dev/cuong/payment/infrastructure/config/SecurityConfig.java
+++ b/backend/src/main/java/dev/cuong/payment/infrastructure/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package dev.cuong.payment.infrastructure.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.cuong.payment.application.port.out.RateLimiter;
+import dev.cuong.payment.infrastructure.logging.MdcLoggingFilter;
 import dev.cuong.payment.infrastructure.ratelimit.RateLimitFilter;
 import dev.cuong.payment.infrastructure.security.JwtAuthenticationFilter;
 import lombok.RequiredArgsConstructor;
@@ -25,6 +26,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final MdcLoggingFilter mdcLoggingFilter;
     private final RateLimiter rateLimiter;
     private final ObjectMapper objectMapper;
 
@@ -47,8 +49,10 @@ public class SecurityConfig {
                         })
                 )
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
-                // Rate limit runs after JWT sets the principal in the SecurityContext
-                .addFilterAfter(new RateLimitFilter(rateLimiter, objectMapper), JwtAuthenticationFilter.class)
+                // MDC populated as soon as JWT auth has set the principal — every subsequent
+                // log line in the request (including rate-limit denials) carries traceId/userId.
+                .addFilterAfter(mdcLoggingFilter, JwtAuthenticationFilter.class)
+                .addFilterAfter(new RateLimitFilter(rateLimiter, objectMapper), MdcLoggingFilter.class)
                 .build();
     }
 

--- a/backend/src/main/java/dev/cuong/payment/infrastructure/kafka/AuditConsumer.java
+++ b/backend/src/main/java/dev/cuong/payment/infrastructure/kafka/AuditConsumer.java
@@ -7,6 +7,7 @@ import dev.cuong.payment.application.port.out.AuditRepository;
 import dev.cuong.payment.domain.model.Account;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -48,8 +49,11 @@ public class AuditConsumer {
     )
     @Transactional
     public void onTransactionEvent(TransactionEventMessage event) {
+        MDC.put("transactionId", event.transactionId().toString());
         try {
             UUID userId = resolveUserId(event);
+            MDC.put("userId", userId.toString());
+
             String metadata = buildMetadata(event);
 
             auditRepository.record(new AuditRepository.AuditEntry(
@@ -60,13 +64,15 @@ public class AuditConsumer {
                     metadata
             ));
 
-            log.info("[AUDIT] Recorded: transactionId={}, eventType={}, userId={}",
-                    event.transactionId(), event.eventType(), userId);
+            log.info("[AUDIT] Recorded: eventType={}", event.eventType());
 
         } catch (Exception e) {
-            log.error("[AUDIT] Failed to record event — will retry: transactionId={}, eventType={}, error={}",
-                    event.transactionId(), event.eventType(), e.getMessage(), e);
+            log.error("[AUDIT] Failed to record event — will retry: eventType={}, error={}",
+                    event.eventType(), e.getMessage(), e);
             throw e;
+        } finally {
+            MDC.remove("transactionId");
+            MDC.remove("userId");
         }
     }
 

--- a/backend/src/main/java/dev/cuong/payment/infrastructure/kafka/NotificationConsumer.java
+++ b/backend/src/main/java/dev/cuong/payment/infrastructure/kafka/NotificationConsumer.java
@@ -1,6 +1,7 @@
 package dev.cuong.payment.infrastructure.kafka;
 
 import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 
@@ -25,13 +26,18 @@ public class NotificationConsumer {
             groupId = "notification"
     )
     public void onTransactionEvent(TransactionEventMessage event) {
-        switch (event.eventType()) {
-            case CREATED    -> notifyInitiated(event);
-            case PROCESSING -> notifyProcessing(event);
-            case SUCCESS    -> notifySucceeded(event);
-            case FAILED     -> notifyFailed(event);
-            case TIMEOUT    -> notifyTimedOut(event);
-            case REFUNDED   -> notifyRefunded(event);
+        MDC.put("transactionId", event.transactionId().toString());
+        try {
+            switch (event.eventType()) {
+                case CREATED    -> notifyInitiated(event);
+                case PROCESSING -> notifyProcessing(event);
+                case SUCCESS    -> notifySucceeded(event);
+                case FAILED     -> notifyFailed(event);
+                case TIMEOUT    -> notifyTimedOut(event);
+                case REFUNDED   -> notifyRefunded(event);
+            }
+        } finally {
+            MDC.remove("transactionId");
         }
     }
 

--- a/backend/src/main/java/dev/cuong/payment/infrastructure/kafka/TransactionProcessingConsumer.java
+++ b/backend/src/main/java/dev/cuong/payment/infrastructure/kafka/TransactionProcessingConsumer.java
@@ -17,6 +17,7 @@ import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
 import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
@@ -82,23 +83,26 @@ public class TransactionProcessingConsumer {
         }
 
         UUID transactionId = message.transactionId();
+        MDC.put("transactionId", transactionId.toString());
         String lockKey = LOCK_PREFIX + transactionId;
 
         boolean locked = distributedLock.tryLock(lockKey, 0, LOCK_LEASE_SECONDS);
         if (!locked) {
-            log.warn("Could not acquire processing lock — another instance is handling: transactionId={}", transactionId);
+            log.warn("Could not acquire processing lock — another instance is handling");
+            MDC.remove("transactionId");
             return;
         }
 
         try {
             process(transactionId);
         } catch (OptimisticLockingFailureException e) {
-            log.warn("Optimistic lock conflict — transaction already processed by another instance: transactionId={}", transactionId);
+            log.warn("Optimistic lock conflict — transaction already processed by another instance");
         } catch (Exception e) {
-            log.error("Unexpected error processing transaction: transactionId={}, error={}", transactionId, e.getMessage(), e);
+            log.error("Unexpected error processing transaction: error={}", e.getMessage(), e);
             throw e; // propagate so Kafka retries via DefaultErrorHandler
         } finally {
             distributedLock.unlock(lockKey);
+            MDC.remove("transactionId");
         }
     }
 

--- a/backend/src/main/java/dev/cuong/payment/infrastructure/logging/MdcLoggingFilter.java
+++ b/backend/src/main/java/dev/cuong/payment/infrastructure/logging/MdcLoggingFilter.java
@@ -1,0 +1,85 @@
+package dev.cuong.payment.infrastructure.logging;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.MDC;
+import org.springframework.lang.NonNull;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.UUID;
+
+/**
+ * Populates SLF4J MDC with three correlation fields for the duration of an HTTP
+ * request, then clears MDC in {@code finally} so no values leak to the next request
+ * served by the same Tomcat thread.
+ *
+ * <p>MDC keys set:
+ * <ul>
+ *   <li>{@code traceId} — generated UUID, one per request. Unconditional.</li>
+ *   <li>{@code userId}  — taken from the authenticated principal in the
+ *       {@link SecurityContextHolder}. Set only for authenticated requests.</li>
+ *   <li>{@code transactionId} — taken from the {@code X-Transaction-Id} request
+ *       header if the client provides it (e.g. for cross-service correlation).</li>
+ * </ul>
+ *
+ * <p>Wired in {@code SecurityConfig} <em>after</em> {@code JwtAuthenticationFilter}
+ * so the principal is already populated when this filter runs.
+ */
+@Component
+public class MdcLoggingFilter extends OncePerRequestFilter {
+
+    static final String MDC_TRACE_ID = "traceId";
+    static final String MDC_USER_ID = "userId";
+    static final String MDC_TRANSACTION_ID = "transactionId";
+
+    private static final String HEADER_TRANSACTION_ID = "X-Transaction-Id";
+
+    @Override
+    protected void doFilterInternal(
+            @NonNull HttpServletRequest request,
+            @NonNull HttpServletResponse response,
+            @NonNull FilterChain filterChain) throws ServletException, IOException {
+
+        try {
+            MDC.put(MDC_TRACE_ID, UUID.randomUUID().toString());
+
+            String userId = currentUserId();
+            if (userId != null) {
+                MDC.put(MDC_USER_ID, userId);
+            }
+
+            String transactionId = request.getHeader(HEADER_TRANSACTION_ID);
+            if (transactionId != null && !transactionId.isBlank()) {
+                MDC.put(MDC_TRANSACTION_ID, transactionId);
+            }
+
+            filterChain.doFilter(request, response);
+        } finally {
+            // Clear all keys this filter could have set — safe because this filter is
+            // the outermost MDC writer for HTTP requests.
+            MDC.remove(MDC_TRACE_ID);
+            MDC.remove(MDC_USER_ID);
+            MDC.remove(MDC_TRANSACTION_ID);
+        }
+    }
+
+    private static String currentUserId() {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth == null || !auth.isAuthenticated()) {
+            return null;
+        }
+        Object principal = auth.getPrincipal();
+        // JwtAuthenticationFilter sets the principal as a UUID; "anonymousUser" string
+        // is the AnonymousAuthenticationFilter's placeholder for unauthenticated requests.
+        if (principal instanceof UUID uuid) {
+            return uuid.toString();
+        }
+        return null;
+    }
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -136,9 +136,6 @@ resilience4j:
           - dev.cuong.payment.domain.exception.PaymentGatewayException
 
 # ── Logging ─────────────────────────────────────────────────────────────────────
-logging:
-  level:
-    dev.cuong.payment: INFO
-    org.springframework.security: WARN
-    org.hibernate.SQL: WARN
-    org.apache.kafka: WARN
+# Logger levels and encoder format are configured in logback-spring.xml so that
+# JSON encoding (production) vs human-readable encoding (local profile) can be
+# switched per Spring profile in one place.

--- a/backend/src/main/resources/logback-spring.xml
+++ b/backend/src/main/resources/logback-spring.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Logging configuration:
+
+  - Default (no profile or any profile other than "local"): one JSON object per line
+    via LogstashEncoder. Suitable for production aggregation (Loki / ELK / Splunk).
+  - "local" profile: human-readable colored pattern with MDC fields appended.
+
+  MDC keys are whitelisted explicitly so stale entries (e.g. from a forgotten
+  MDC.put without a matching MDC.remove) cannot pollute production output.
+-->
+<configuration>
+
+    <springProfile name="local">
+        <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+            <encoder>
+                <pattern>%d{HH:mm:ss.SSS} %highlight(%-5level) [%thread] %cyan(%logger{36}) [traceId=%X{traceId:-} userId=%X{userId:-} txId=%X{transactionId:-}] - %msg%n</pattern>
+            </encoder>
+        </appender>
+
+        <root level="INFO">
+            <appender-ref ref="CONSOLE"/>
+        </root>
+
+        <logger name="dev.cuong.payment" level="INFO"/>
+        <logger name="org.springframework.security" level="WARN"/>
+        <logger name="org.hibernate.SQL" level="WARN"/>
+        <logger name="org.apache.kafka" level="WARN"/>
+    </springProfile>
+
+    <springProfile name="!local">
+        <appender name="JSON" class="ch.qos.logback.core.ConsoleAppender">
+            <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+                <fieldNames>
+                    <timestamp>timestamp</timestamp>
+                    <message>message</message>
+                    <logger>logger</logger>
+                    <thread>thread</thread>
+                    <level>level</level>
+                    <levelValue>[ignore]</levelValue>
+                    <version>[ignore]</version>
+                </fieldNames>
+                <!--
+                  Whitelist: only these MDC keys appear in JSON output. Anything else
+                  in MDC (Spring/Kafka internal keys, accidentally-leaked entries) is
+                  ignored, keeping the schema stable.
+                -->
+                <includeMdcKeyName>traceId</includeMdcKeyName>
+                <includeMdcKeyName>userId</includeMdcKeyName>
+                <includeMdcKeyName>transactionId</includeMdcKeyName>
+            </encoder>
+        </appender>
+
+        <root level="INFO">
+            <appender-ref ref="JSON"/>
+        </root>
+
+        <logger name="dev.cuong.payment" level="INFO"/>
+        <logger name="org.springframework.security" level="WARN"/>
+        <logger name="org.hibernate.SQL" level="WARN"/>
+        <logger name="org.apache.kafka" level="WARN"/>
+    </springProfile>
+
+</configuration>

--- a/backend/src/test/java/dev/cuong/payment/infrastructure/logging/JsonLogOutputIntegrationTest.java
+++ b/backend/src/test/java/dev/cuong/payment/infrastructure/logging/JsonLogOutputIntegrationTest.java
@@ -1,0 +1,106 @@
+package dev.cuong.payment.infrastructure.logging;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+
+/**
+ * Verifies that with the JSON-encoder profile (default — anything not "local"),
+ * each log line emitted by the application is a single, parseable JSON object
+ * with the schema defined in {@code logback-spring.xml}.
+ *
+ * <p>An HTTP request triggers logs from the controller path. We then parse the
+ * captured stdout, find a log line whose {@code logger} is one we control, and
+ * assert that it carries the expected fields.
+ *
+ * <p>Authentication is intentionally <em>not</em> performed: the request hits
+ * an endpoint that requires auth, gets a 401, and we still expect at least one
+ * structured log line from the request lifecycle (Spring's RequestMappingHandlerMapping,
+ * etc.). For asserting MDC presence we use a logger that fires unconditionally.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@Testcontainers
+@ExtendWith(OutputCaptureExtension.class)
+@TestPropertySource(properties = {
+        "spring.autoconfigure.exclude=" +
+                "org.redisson.spring.starter.RedissonAutoConfigurationV2," +
+                "org.springframework.boot.autoconfigure.kafka.KafkaAutoConfiguration",
+        "spring.flyway.enabled=true",
+        "spring.jpa.hibernate.ddl-auto=validate"
+})
+class JsonLogOutputIntegrationTest {
+
+    static final PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:15-alpine");
+
+    static {
+        postgres.start();
+    }
+
+    @DynamicPropertySource
+    static void overrideProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", postgres::getJdbcUrl);
+        registry.add("spring.datasource.username", postgres::getUsername);
+        registry.add("spring.datasource.password", postgres::getPassword);
+    }
+
+    @Autowired MockMvc mockMvc;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    void should_emit_each_log_line_as_a_single_JSON_object_with_required_fields(CapturedOutput output)
+            throws Exception {
+        // Trigger a request — the resulting Spring Security DEBUG/INFO logs go through
+        // our LogstashEncoder. We use /actuator/health (permitAll) so we don't get a 401.
+        mockMvc.perform(get("/actuator/health")).andReturn();
+
+        // Find any log line that parses as JSON and carries our schema.
+        Optional<JsonNode> structured = output.getAll()
+                .lines()
+                .map(this::tryParseJson)
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .filter(node -> node.has("timestamp") && node.has("level") && node.has("logger") && node.has("message"))
+                .findFirst();
+
+        assertThat(structured)
+                .as("at least one log line must be valid JSON with timestamp/level/logger/message")
+                .isPresent();
+
+        JsonNode line = structured.get();
+        assertThat(line.get("timestamp").asText()).isNotBlank();
+        assertThat(line.get("level").asText()).isIn("INFO", "WARN", "ERROR", "DEBUG", "TRACE");
+        assertThat(line.get("logger").asText()).isNotBlank();
+        assertThat(line.get("message").asText()).isNotBlank();
+    }
+
+    private Optional<JsonNode> tryParseJson(String line) {
+        String trimmed = line.trim();
+        if (trimmed.isEmpty() || !trimmed.startsWith("{")) {
+            return Optional.empty();
+        }
+        try {
+            return Optional.of(objectMapper.readTree(trimmed));
+        } catch (Exception e) {
+            return Optional.empty();
+        }
+    }
+}

--- a/backend/src/test/java/dev/cuong/payment/infrastructure/logging/MdcLoggingFilterTest.java
+++ b/backend/src/test/java/dev/cuong/payment/infrastructure/logging/MdcLoggingFilterTest.java
@@ -1,0 +1,167 @@
+package dev.cuong.payment.infrastructure.logging;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.MDC;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link MdcLoggingFilter}. The filter is invoked directly with mock
+ * servlet primitives — no Spring context needed.
+ *
+ * <p>Each test asserts both the values present <em>during</em> the filter chain
+ * (via a recording {@link FilterChain}) and that MDC is empty <em>after</em> the
+ * filter returns. The latter is the critical thread-leak guard.
+ */
+class MdcLoggingFilterTest {
+
+    private final MdcLoggingFilter filter = new MdcLoggingFilter();
+
+    @AfterEach
+    void clearStaticState() {
+        SecurityContextHolder.clearContext();
+        MDC.clear();
+    }
+
+    @Test
+    void should_set_traceId_and_userId_during_chain_when_request_is_authenticated() throws Exception {
+        UUID userId = UUID.randomUUID();
+        authenticate(userId);
+
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/transactions");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        RecordingFilterChain chain = new RecordingFilterChain();
+        filter.doFilter(request, response, chain);
+
+        assertThat(chain.capturedTraceId.get()).isNotBlank();
+        // Valid UUID
+        UUID.fromString(chain.capturedTraceId.get());
+        assertThat(chain.capturedUserId.get()).isEqualTo(userId.toString());
+        assertThat(chain.capturedTransactionId.get()).isNull();
+    }
+
+    @Test
+    void should_set_transactionId_when_X_Transaction_Id_header_present() throws Exception {
+        authenticate(UUID.randomUUID());
+
+        UUID inboundTxId = UUID.randomUUID();
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/transactions");
+        request.addHeader("X-Transaction-Id", inboundTxId.toString());
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        RecordingFilterChain chain = new RecordingFilterChain();
+        filter.doFilter(request, response, chain);
+
+        assertThat(chain.capturedTransactionId.get()).isEqualTo(inboundTxId.toString());
+    }
+
+    @Test
+    void should_set_only_traceId_when_request_is_unauthenticated() throws Exception {
+        // No SecurityContextHolder.getContext().setAuthentication(...) — anonymous
+
+        MockHttpServletRequest request = new MockHttpServletRequest("POST", "/api/auth/login");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        RecordingFilterChain chain = new RecordingFilterChain();
+        filter.doFilter(request, response, chain);
+
+        assertThat(chain.capturedTraceId.get()).isNotBlank();
+        assertThat(chain.capturedUserId.get()).isNull();
+    }
+
+    @Test
+    void should_clear_MDC_after_chain_completes_successfully() throws Exception {
+        authenticate(UUID.randomUUID());
+
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/transactions");
+        request.addHeader("X-Transaction-Id", UUID.randomUUID().toString());
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter.doFilter(request, response, new RecordingFilterChain());
+
+        assertThat(MDC.get("traceId")).isNull();
+        assertThat(MDC.get("userId")).isNull();
+        assertThat(MDC.get("transactionId")).isNull();
+    }
+
+    @Test
+    void should_clear_MDC_even_when_chain_throws() {
+        authenticate(UUID.randomUUID());
+
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/transactions");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        FilterChain throwingChain = (req, res) -> { throw new ServletException("boom"); };
+
+        try {
+            filter.doFilter(request, response, throwingChain);
+        } catch (ServletException | IOException expected) {
+            // expected
+        }
+
+        assertThat(MDC.get("traceId")).isNull();
+        assertThat(MDC.get("userId")).isNull();
+        assertThat(MDC.get("transactionId")).isNull();
+    }
+
+    @Test
+    void should_generate_a_fresh_traceId_per_request() throws Exception {
+        authenticate(UUID.randomUUID());
+
+        RecordingFilterChain chain1 = new RecordingFilterChain();
+        filter.doFilter(new MockHttpServletRequest(), new MockHttpServletResponse(), chain1);
+
+        RecordingFilterChain chain2 = new RecordingFilterChain();
+        filter.doFilter(new MockHttpServletRequest(), new MockHttpServletResponse(), chain2);
+
+        assertThat(chain1.capturedTraceId.get())
+                .isNotBlank()
+                .isNotEqualTo(chain2.capturedTraceId.get());
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private static void authenticate(UUID userId) {
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken(
+                        userId,
+                        null,
+                        List.of(new SimpleGrantedAuthority("ROLE_USER"))));
+    }
+
+    /** Captures MDC values at the moment the chain is invoked (mid-filter). */
+    private static class RecordingFilterChain implements FilterChain {
+        final AtomicReference<String> capturedTraceId = new AtomicReference<>();
+        final AtomicReference<String> capturedUserId = new AtomicReference<>();
+        final AtomicReference<String> capturedTransactionId = new AtomicReference<>();
+
+        @Override
+        public void doFilter(jakarta.servlet.ServletRequest req, jakarta.servlet.ServletResponse res) {
+            capturedTraceId.set(MDC.get("traceId"));
+            capturedUserId.set(MDC.get("userId"));
+            capturedTransactionId.set(MDC.get("transactionId"));
+        }
+
+        @Override
+        public String toString() {
+            return "RecordingFilterChain{traceId=" + capturedTraceId.get()
+                    + ", userId=" + capturedUserId.get()
+                    + ", transactionId=" + capturedTransactionId.get() + "}";
+        }
+    }
+
+}


### PR DESCRIPTION
## What this PR does
Closes #18 

Adds structured JSON logging for production with three correlation
fields (traceId, userId, transactionId) propagated via SLF4J's MDC.
Local profile keeps the human-readable pattern. The HTTP filter sets
MDC after JWT authentication so every log line in a request — including
rate-limit denials — carries the correlation context. The three Kafka
consumers each set transactionId in MDC for the duration of message
processing, with the audit consumer also setting userId after its DB
resolution.

## How to test

1. **Unit tests** (no infrastructure):
   `./gradlew test --tests dev.cuong.payment.infrastructure.logging.MdcLoggingFilterTest`
2. **Integration test** (Postgres in Testcontainers):
   `./gradlew test --tests dev.cuong.payment.infrastructure.logging.JsonLogOutputIntegrationTest`
3. **Full suite**: `./gradlew test`
4. **Manual local run** (human format): `.\gradlew.bat bootRun`
Hit any endpoint — log lines should be colored text with
`[traceId=... userId=... txId=...]` brackets.
5. **Manual prod-like run** (JSON format): `.\gradlew.bat bootRun`
Hit any endpoint — log lines are single-line JSON objects.

## Technical decisions

**Filter ordering JwtAuth → MdcLogging → RateLimit**: ensures rate-limit
denial logs (429) carry correlation context. The alternative — placing
MdcLoggingFilter before all auth filters and using a second mechanism
to populate userId later — was rejected as over-engineered.

**MDC.remove(key) per key in Kafka consumers, MDC.clear() not used**:
Spring Kafka may add its own MDC entries upstream of the listener
method. Removing only the keys we set avoids stomping on framework
context.

**MDC key whitelist in LogstashEncoder**: only `traceId`, `userId`,
`transactionId` make it into JSON output. Anything else in MDC
(framework leakage, future debug additions) is ignored. Stable schema
for log aggregators.