### PR TITLE
Task/21 admin panel

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,6 @@
 import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom';
 import { ProtectedRoute } from '@/components/ProtectedRoute';
+import AdminPanel from '@/pages/AdminPanel';
 import Dashboard from '@/pages/Dashboard';
 import Login from '@/pages/Login';
 import Register from '@/pages/Register';
@@ -37,6 +38,14 @@ export default function App() {
           element={
             <ProtectedRoute>
               <Dashboard />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/admin"
+          element={
+            <ProtectedRoute requiredRole="ADMIN">
+              <AdminPanel />
             </ProtectedRoute>
           }
         />

--- a/frontend/src/api/adminApi.ts
+++ b/frontend/src/api/adminApi.ts
@@ -1,0 +1,43 @@
+import { apiClient } from './client';
+import type {
+  CircuitBreakerStatus,
+  DlqEvent,
+  PagedResult,
+  Transaction,
+  TransactionStatus,
+} from './types';
+
+/**
+ * Typed wrappers around the backend's {@code /api/admin/*} endpoints.
+ * All endpoints require {@code ROLE_ADMIN} on the JWT — a 403 surfaces as a
+ * regular AxiosError that the calling code normalises via {@code toApiError}.
+ */
+export const adminApi = {
+  getDlqEvents(page = 0, size = 50): Promise<PagedResult<DlqEvent>> {
+    return apiClient
+      .get<PagedResult<DlqEvent>>('/api/admin/dlq', { params: { page, size } })
+      .then((res) => res.data);
+  },
+
+  retryDlqEvent(dlqEventId: string): Promise<void> {
+    return apiClient.post(`/api/admin/dlq/${dlqEventId}/retry`).then(() => undefined);
+  },
+
+  getAllTransactions(
+    page = 0,
+    size = 50,
+    status?: TransactionStatus,
+  ): Promise<PagedResult<Transaction>> {
+    const params: Record<string, string | number> = { page, size };
+    if (status) params.status = status;
+    return apiClient
+      .get<PagedResult<Transaction>>('/api/admin/transactions', { params })
+      .then((res) => res.data);
+  },
+
+  getCircuitBreakerStatus(): Promise<CircuitBreakerStatus> {
+    return apiClient
+      .get<CircuitBreakerStatus>('/api/admin/circuit-breaker')
+      .then((res) => res.data);
+  },
+};

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -101,3 +101,41 @@ export interface ApiError {
   code: string;
   message: string;
 }
+
+// ── Admin ─────────────────────────────────────────────────────────────────────
+
+/**
+ * One row from {@code GET /api/admin/dlq}. {@code transactionId} and
+ * {@code eventType} are pre-parsed by the backend adapter from the JSON
+ * payload; either may be {@code null} when the payload was unreadable.
+ */
+export interface DlqEvent {
+  id: string;
+  topic: string;
+  kafkaPartition: number | null;
+  kafkaOffset: number | null;
+  payload: string;
+  transactionId: string | null;
+  eventType: string | null;
+  errorMessage: string;
+  retryCount: number;
+  createdAt: string;
+  resolvedAt: string | null;
+  resolvedBy: string | null;
+}
+
+export type CircuitBreakerState = 'CLOSED' | 'OPEN' | 'HALF_OPEN' | 'DISABLED' | 'FORCED_OPEN' | 'METRICS_ONLY';
+
+/**
+ * Snapshot of {@code payment-gateway} circuit breaker. {@code failureRate}
+ * and {@code slowCallRate} are {@code -1} when the sliding window has not
+ * yet observed enough calls — the UI should render that as "—".
+ */
+export interface CircuitBreakerStatus {
+  name: string;
+  state: CircuitBreakerState;
+  failureRate: number;
+  slowCallRate: number;
+  bufferedCalls: number;
+  failedCalls: number;
+}

--- a/frontend/src/components/CircuitBreakerCard.tsx
+++ b/frontend/src/components/CircuitBreakerCard.tsx
@@ -1,0 +1,54 @@
+import type { CircuitBreakerStatus } from '@/api/types';
+
+/**
+ * Snapshot card for the {@code payment-gateway} circuit breaker. Renders the
+ * current state with state-keyed colour styling, plus the call-window
+ * metrics. Failure / slow-call rates of {@code -1} indicate the sliding
+ * window doesn't yet have enough calls — rendered as "—" rather than "-100%".
+ */
+interface CircuitBreakerCardProps {
+  status: CircuitBreakerStatus | null;
+  loading: boolean;
+}
+
+export function CircuitBreakerCard({ status, loading }: CircuitBreakerCardProps) {
+  if (loading && status === null) {
+    return <p>Loading circuit breaker status…</p>;
+  }
+
+  if (status === null) {
+    return <p className="tx-table__empty">No circuit breaker data.</p>;
+  }
+
+  return (
+    <div className="cb-card" data-state={status.state}>
+      <div className="cb-card__title">
+        <span>{status.name}</span>
+        <span className="cb-card__state">{status.state}</span>
+      </div>
+      <dl className="cb-card__metrics">
+        <div>
+          <dt>Failure rate</dt>
+          <dd>{formatRate(status.failureRate)}</dd>
+        </div>
+        <div>
+          <dt>Slow-call rate</dt>
+          <dd>{formatRate(status.slowCallRate)}</dd>
+        </div>
+        <div>
+          <dt>Buffered calls</dt>
+          <dd>{status.bufferedCalls}</dd>
+        </div>
+        <div>
+          <dt>Failed calls</dt>
+          <dd>{status.failedCalls}</dd>
+        </div>
+      </dl>
+    </div>
+  );
+}
+
+function formatRate(rate: number): string {
+  if (rate < 0) return '—';
+  return `${rate.toFixed(1)}%`;
+}

--- a/frontend/src/components/DlqTable.tsx
+++ b/frontend/src/components/DlqTable.tsx
@@ -1,0 +1,103 @@
+import { useState } from 'react';
+import type { DlqEvent } from '@/api/types';
+
+/**
+ * Pure presentational DLQ list. Each row gets a "Retry" button when the
+ * event is unresolved; clicking it calls {@code onRetry} and disables the
+ * button until the parent's mutation settles (the parent re-fetches and
+ * the row either disappears or shows a `resolvedAt` timestamp).
+ */
+interface DlqTableProps {
+  events: DlqEvent[];
+  loading: boolean;
+  onRetry: (id: string) => Promise<void>;
+}
+
+export function DlqTable({ events, loading, onRetry }: DlqTableProps) {
+  const [pendingId, setPendingId] = useState<string | null>(null);
+
+  if (loading && events.length === 0) {
+    return <p>Loading dead-letter events…</p>;
+  }
+
+  if (events.length === 0) {
+    return <p className="tx-table__empty">No dead-letter events. 🎉</p>;
+  }
+
+  async function handleRetry(id: string) {
+    setPendingId(id);
+    try {
+      await onRetry(id);
+    } finally {
+      setPendingId(null);
+    }
+  }
+
+  return (
+    <table className="tx-table" aria-label="dead-letter events">
+      <thead>
+        <tr>
+          <th>Created</th>
+          <th>Event type</th>
+          <th>Transaction</th>
+          <th>Error</th>
+          <th>Resolved</th>
+          <th aria-label="actions" />
+        </tr>
+      </thead>
+      <tbody>
+        {events.map((e) => {
+          const resolved = e.resolvedAt !== null;
+          const isPending = pendingId === e.id;
+          return (
+            <tr key={e.id} data-resolved={resolved}>
+              <td title={e.createdAt}>{formatTimestamp(e.createdAt)}</td>
+              <td>{e.eventType ?? <span className="tx-table__missing">unparseable</span>}</td>
+              <td>
+                {e.transactionId ? (
+                  <code title={e.transactionId}>{shortId(e.transactionId)}</code>
+                ) : (
+                  <span className="tx-table__missing">—</span>
+                )}
+              </td>
+              <td title={e.errorMessage}>{truncate(e.errorMessage, 80)}</td>
+              <td>
+                {resolved ? (
+                  <span title={`${e.resolvedAt} by ${e.resolvedBy}`}>
+                    {formatTimestamp(e.resolvedAt!)}
+                  </span>
+                ) : (
+                  <span className="tx-table__missing">—</span>
+                )}
+              </td>
+              <td>
+                {!resolved && (
+                  <button
+                    type="button"
+                    onClick={() => void handleRetry(e.id)}
+                    disabled={isPending}
+                  >
+                    {isPending ? 'Retrying…' : 'Retry'}
+                  </button>
+                )}
+              </td>
+            </tr>
+          );
+        })}
+      </tbody>
+    </table>
+  );
+}
+
+function formatTimestamp(iso: string): string {
+  const d = new Date(iso);
+  return Number.isNaN(d.getTime()) ? iso : d.toLocaleString();
+}
+
+function shortId(id: string): string {
+  return id.length <= 12 ? id : `${id.slice(0, 8)}…${id.slice(-4)}`;
+}
+
+function truncate(s: string, max: number): string {
+  return s.length <= max ? s : `${s.slice(0, max - 1)}…`;
+}

--- a/frontend/src/components/ProtectedRoute.tsx
+++ b/frontend/src/components/ProtectedRoute.tsx
@@ -1,26 +1,38 @@
 import type { ReactNode } from 'react';
 import { Navigate, useLocation } from 'react-router-dom';
+import type { Role } from '@/api/types';
 import { selectIsAuthenticated, useAuthStore } from '@/store/auth';
 
 /**
- * Wraps a route element. If the auth store has no token, redirects to
- * {@code /login} with the originally-requested path stashed in
- * {@code location.state.from} so the login page can bounce back after success.
+ * Wraps a route element. Redirects unauthenticated visitors to {@code /login}
+ * with the originally-requested path stashed in {@code location.state.from}
+ * so the login page can bounce back after success.
+ *
+ * <p>If {@code requiredRole} is set and the authenticated user's role doesn't
+ * match, redirects to {@code /dashboard} (the regular landing page) — the
+ * server is the authoritative authorization boundary; the route guard just
+ * keeps the URL bar honest.
  *
  * <p>Authentication state is hydrated synchronously from localStorage by the
- * Zustand persist middleware, so this guard is correct on first render — no
- * need for a "loading" flicker on full-page reload.
+ * Zustand persist middleware, so this guard is correct on first render.
  */
 interface ProtectedRouteProps {
   children: ReactNode;
+  /** Optional role gate. When set, the user must have this exact role. */
+  requiredRole?: Role;
 }
 
-export function ProtectedRoute({ children }: ProtectedRouteProps) {
+export function ProtectedRoute({ children, requiredRole }: ProtectedRouteProps) {
   const isAuthenticated = useAuthStore(selectIsAuthenticated);
+  const role = useAuthStore((s) => s.role);
   const location = useLocation();
 
   if (!isAuthenticated) {
     return <Navigate to="/login" replace state={{ from: location.pathname }} />;
+  }
+
+  if (requiredRole && role !== requiredRole) {
+    return <Navigate to="/dashboard" replace />;
   }
 
   return <>{children}</>;

--- a/frontend/src/components/StatusDistributionChart.tsx
+++ b/frontend/src/components/StatusDistributionChart.tsx
@@ -1,0 +1,73 @@
+import { useMemo } from 'react';
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Cell,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+import type { Transaction, TransactionStatus } from '@/api/types';
+
+/**
+ * Bar chart of transaction count by status. Aggregation runs over whatever
+ * page of admin transactions the parent passed in — the chart faithfully
+ * reflects the current viewport, not the global system state.
+ */
+interface StatusDistributionChartProps {
+  transactions: Transaction[];
+}
+
+const STATUS_ORDER: TransactionStatus[] = [
+  'PENDING',
+  'PROCESSING',
+  'SUCCESS',
+  'FAILED',
+  'TIMEOUT',
+  'REFUNDED',
+];
+
+const STATUS_COLOR: Record<TransactionStatus, string> = {
+  PENDING:    '#f59e0b',
+  PROCESSING: '#3b82f6',
+  SUCCESS:    '#10b981',
+  FAILED:     '#ef4444',
+  TIMEOUT:    '#dc2626',
+  REFUNDED:   '#6b7280',
+};
+
+export function StatusDistributionChart({ transactions }: StatusDistributionChartProps) {
+  const data = useMemo(() => {
+    const counts: Record<TransactionStatus, number> = {
+      PENDING: 0, PROCESSING: 0, SUCCESS: 0, FAILED: 0, TIMEOUT: 0, REFUNDED: 0,
+    };
+    for (const tx of transactions) {
+      counts[tx.status] = (counts[tx.status] ?? 0) + 1;
+    }
+    return STATUS_ORDER.map((status) => ({ status, count: counts[status] }));
+  }, [transactions]);
+
+  if (transactions.length === 0) {
+    return <p className="tx-table__empty">No transactions to chart yet.</p>;
+  }
+
+  return (
+    <div className="chart-container">
+      <ResponsiveContainer width="100%" height={240}>
+        <BarChart data={data} margin={{ top: 10, right: 16, left: 0, bottom: 0 }}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis dataKey="status" tick={{ fontSize: 12 }} />
+          <YAxis allowDecimals={false} tick={{ fontSize: 12 }} />
+          <Tooltip />
+          <Bar dataKey="count" name="Transactions">
+            {data.map((entry) => (
+              <Cell key={entry.status} fill={STATUS_COLOR[entry.status]} />
+            ))}
+          </Bar>
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/frontend/src/pages/AdminPanel.tsx
+++ b/frontend/src/pages/AdminPanel.tsx
@@ -1,0 +1,134 @@
+import { useEffect, useRef, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { adminApi } from '@/api/adminApi';
+import { toApiError } from '@/api/client';
+import { CircuitBreakerCard } from '@/components/CircuitBreakerCard';
+import { DlqTable } from '@/components/DlqTable';
+import { StatusDistributionChart } from '@/components/StatusDistributionChart';
+import type {
+  CircuitBreakerStatus,
+  DlqEvent,
+  Transaction,
+} from '@/api/types';
+
+const POLL_INTERVAL_MS = 3000;
+
+/**
+ * Admin-only operations panel. Polls three endpoints in parallel every 3 s
+ * — DLQ list, circuit breaker status, and admin-scoped transactions for the
+ * status-distribution chart. Same in-flight guard pattern as the dashboard
+ * so a slow request never overlaps the next tick.
+ */
+export default function AdminPanel() {
+  const [dlqEvents, setDlqEvents] = useState<DlqEvent[]>([]);
+  const [dlqLoading, setDlqLoading] = useState(true);
+  const [dlqError, setDlqError] = useState<string | null>(null);
+
+  const [cbStatus, setCbStatus] = useState<CircuitBreakerStatus | null>(null);
+  const [cbLoading, setCbLoading] = useState(true);
+  const [cbError, setCbError] = useState<string | null>(null);
+
+  const [transactions, setTransactions] = useState<Transaction[]>([]);
+  const [txError, setTxError] = useState<string | null>(null);
+
+  const inFlightRef = useRef(false);
+
+  async function refresh() {
+    if (inFlightRef.current) return;
+    inFlightRef.current = true;
+    try {
+      const [dlqResult, cbResult, txResult] = await Promise.allSettled([
+        adminApi.getDlqEvents(),
+        adminApi.getCircuitBreakerStatus(),
+        adminApi.getAllTransactions(),
+      ]);
+
+      if (dlqResult.status === 'fulfilled') {
+        setDlqEvents(dlqResult.value.data);
+        setDlqError(null);
+      } else {
+        setDlqError(toApiError(dlqResult.reason).message);
+      }
+
+      if (cbResult.status === 'fulfilled') {
+        setCbStatus(cbResult.value);
+        setCbError(null);
+      } else {
+        setCbError(toApiError(cbResult.reason).message);
+      }
+
+      if (txResult.status === 'fulfilled') {
+        setTransactions(txResult.value.data);
+        setTxError(null);
+      } else {
+        setTxError(toApiError(txResult.reason).message);
+      }
+    } finally {
+      setDlqLoading(false);
+      setCbLoading(false);
+      inFlightRef.current = false;
+    }
+  }
+
+  useEffect(() => {
+    let cancelled = false;
+    const tick = () => {
+      if (!cancelled) void refresh();
+    };
+    tick();
+    const id = window.setInterval(tick, POLL_INTERVAL_MS);
+    return () => {
+      cancelled = true;
+      window.clearInterval(id);
+    };
+  }, []);
+
+  async function handleRetry(id: string) {
+    try {
+      await adminApi.retryDlqEvent(id);
+      // Trigger an immediate refresh so the resolved row reflects the new state
+      // before the next poll tick.
+      await refresh();
+    } catch (err) {
+      setDlqError(toApiError(err).message);
+    }
+  }
+
+  return (
+    <main className="page page--wide">
+      <header className="page__header">
+        <h1>Admin panel</h1>
+        <Link to="/dashboard">Back to dashboard</Link>
+      </header>
+
+      <section className="page__section">
+        <h2>Payment-gateway circuit breaker</h2>
+        {cbError && (
+          <p className="banner-error" role="alert">Circuit breaker: {cbError}</p>
+        )}
+        <CircuitBreakerCard status={cbStatus} loading={cbLoading} />
+      </section>
+
+      <section className="page__section">
+        <h2>Transactions by status</h2>
+        {txError && (
+          <p className="banner-error" role="alert">Transactions: {txError}</p>
+        )}
+        <StatusDistributionChart transactions={transactions} />
+      </section>
+
+      <section className="page__section">
+        <div className="section__header">
+          <h2>Dead-letter queue</h2>
+          <button type="button" onClick={() => void refresh()} disabled={inFlightRef.current}>
+            Refresh
+          </button>
+        </div>
+        {dlqError && (
+          <p className="banner-error" role="alert">DLQ: {dlqError}</p>
+        )}
+        <DlqTable events={dlqEvents} loading={dlqLoading} onRetry={handleRetry} />
+      </section>
+    </main>
+  );
+}

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { CreateTransactionModal } from '@/components/CreateTransactionModal';
 import { TransactionTable } from '@/components/TransactionTable';
 import { useAccountStore } from '@/store/account';
@@ -19,6 +19,7 @@ const POLL_INTERVAL_MS = 3000;
 export default function Dashboard() {
   const navigate = useNavigate();
   const username = useAuthStore((s) => s.username);
+  const role = useAuthStore((s) => s.role);
   const clear = useAuthStore((s) => s.clear);
 
   const account = useAccountStore((s) => s.data);
@@ -66,7 +67,10 @@ export default function Dashboard() {
     <main className="page page--wide">
       <header className="page__header">
         <h1>Welcome, {username}</h1>
-        <button type="button" onClick={handleLogout}>Sign out</button>
+        <nav className="page__header-actions">
+          {role === 'ADMIN' && <Link to="/admin">Admin panel</Link>}
+          <button type="button" onClick={handleLogout}>Sign out</button>
+        </nav>
       </header>
 
       <section className="page__section">

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -178,3 +178,70 @@ body {
   gap: 0.5rem;
   margin-top: 0.5rem;
 }
+
+/* ── Page header actions group ────────────────────────────────────────────── */
+
+.page__header-actions {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+/* ── Circuit breaker card ─────────────────────────────────────────────────── */
+
+.cb-card {
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  padding: 1rem 1.25rem;
+  max-width: 480px;
+  border-left-width: 4px;
+}
+
+.cb-card[data-state='CLOSED']    { border-left-color: #10b981; }
+.cb-card[data-state='HALF_OPEN'] { border-left-color: #f59e0b; }
+.cb-card[data-state='OPEN'],
+.cb-card[data-state='FORCED_OPEN'] { border-left-color: #ef4444; }
+.cb-card[data-state='DISABLED'],
+.cb-card[data-state='METRICS_ONLY'] { border-left-color: var(--color-text-muted); }
+
+.cb-card__title {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+}
+
+.cb-card__state {
+  font-size: 0.85rem;
+  letter-spacing: 0.05em;
+}
+
+.cb-card__metrics {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 0.5rem 1rem;
+  margin: 0;
+}
+
+.cb-card__metrics div {
+  display: flex;
+  justify-content: space-between;
+}
+
+.cb-card__metrics dt {
+  color: var(--color-text-muted);
+  font-size: 0.85rem;
+}
+
+.cb-card__metrics dd {
+  margin: 0;
+  font-weight: 600;
+}
+
+/* ── Chart container ──────────────────────────────────────────────────────── */
+
+.chart-container {
+  width: 100%;
+  max-width: 720px;
+}

--- a/frontend/src/test/CircuitBreakerCard.test.tsx
+++ b/frontend/src/test/CircuitBreakerCard.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from '@testing-library/react';
+import { CircuitBreakerCard } from '@/components/CircuitBreakerCard';
+import type { CircuitBreakerStatus } from '@/api/types';
+
+function makeStatus(overrides: Partial<CircuitBreakerStatus> = {}): CircuitBreakerStatus {
+  return {
+    name: 'payment-gateway',
+    state: 'CLOSED',
+    failureRate: 5.5,
+    slowCallRate: 12.3,
+    bufferedCalls: 10,
+    failedCalls: 1,
+    ...overrides,
+  };
+}
+
+describe('CircuitBreakerCard', () => {
+  it('should_show_loading_message_when_status_is_null_and_loading', () => {
+    render(<CircuitBreakerCard status={null} loading={true} />);
+    expect(screen.getByText(/loading circuit breaker status/i)).toBeInTheDocument();
+  });
+
+  it('should_render_state_and_metrics_when_status_present', () => {
+    render(<CircuitBreakerCard status={makeStatus()} loading={false} />);
+    expect(screen.getByText('payment-gateway')).toBeInTheDocument();
+    expect(screen.getByText('CLOSED')).toBeInTheDocument();
+    expect(screen.getByText('5.5%')).toBeInTheDocument();
+    expect(screen.getByText('12.3%')).toBeInTheDocument();
+    expect(screen.getByText('10')).toBeInTheDocument(); // bufferedCalls
+    expect(screen.getByText('1')).toBeInTheDocument();  // failedCalls
+  });
+
+  it('should_render_dash_when_rate_is_negative_one_meaning_insufficient_data', () => {
+    render(
+      <CircuitBreakerCard
+        status={makeStatus({ failureRate: -1, slowCallRate: -1 })}
+        loading={false}
+      />,
+    );
+    // Both rates render as "—"
+    const dashes = screen.getAllByText('—');
+    expect(dashes).toHaveLength(2);
+  });
+
+  it('should_carry_data_state_attribute_for_state_keyed_styling', () => {
+    const { container } = render(
+      <CircuitBreakerCard status={makeStatus({ state: 'OPEN' })} loading={false} />,
+    );
+    const card = container.querySelector('.cb-card');
+    expect(card).toHaveAttribute('data-state', 'OPEN');
+  });
+});

--- a/frontend/src/test/DlqTable.test.tsx
+++ b/frontend/src/test/DlqTable.test.tsx
@@ -1,0 +1,93 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { DlqTable } from '@/components/DlqTable';
+import type { DlqEvent } from '@/api/types';
+
+function makeEvent(overrides: Partial<DlqEvent> = {}): DlqEvent {
+  return {
+    id: 'dlq-1',
+    topic: 'payment.transaction.events',
+    kafkaPartition: 0,
+    kafkaOffset: 42,
+    payload: '{"transactionId":"abc","eventType":"PROCESSING"}',
+    transactionId: 'abc12345-abcd-abcd-abcd-abcdef123456',
+    eventType: 'PROCESSING',
+    errorMessage: 'SIMULATED_FAILURE',
+    retryCount: 0,
+    createdAt: '2026-04-28T12:00:00Z',
+    resolvedAt: null,
+    resolvedBy: null,
+    ...overrides,
+  };
+}
+
+describe('DlqTable', () => {
+  it('should_show_loading_message_when_loading_and_no_events_yet', () => {
+    render(<DlqTable events={[]} loading={true} onRetry={vi.fn()} />);
+    expect(screen.getByText(/loading dead-letter events/i)).toBeInTheDocument();
+  });
+
+  it('should_show_empty_state_when_no_events_and_not_loading', () => {
+    render(<DlqTable events={[]} loading={false} onRetry={vi.fn()} />);
+    expect(screen.getByText(/no dead-letter events/i)).toBeInTheDocument();
+  });
+
+  it('should_render_a_retry_button_only_for_unresolved_events', () => {
+    const events = [
+      makeEvent({ id: 'unresolved' }),
+      makeEvent({
+        id: 'resolved',
+        resolvedAt: '2026-04-28T12:30:00Z',
+        resolvedBy: 'admin-retry',
+      }),
+    ];
+    render(<DlqTable events={events} loading={false} onRetry={vi.fn()} />);
+    const retryButtons = screen.getAllByRole('button', { name: /retry/i });
+    expect(retryButtons).toHaveLength(1);
+  });
+
+  it('should_call_onRetry_with_event_id_when_retry_button_clicked', async () => {
+    const onRetry = vi.fn().mockResolvedValue(undefined);
+    render(<DlqTable events={[makeEvent({ id: 'dlq-77' })]} loading={false} onRetry={onRetry} />);
+
+    await userEvent.setup().click(screen.getByRole('button', { name: /retry/i }));
+
+    await waitFor(() => {
+      expect(onRetry).toHaveBeenCalledWith('dlq-77');
+    });
+  });
+
+  it('should_disable_retry_button_while_retry_is_in_flight', async () => {
+    let resolveRetry: () => void = () => {};
+    const onRetry = vi.fn().mockReturnValue(
+      new Promise<void>((resolve) => {
+        resolveRetry = resolve;
+      }),
+    );
+
+    render(<DlqTable events={[makeEvent()]} loading={false} onRetry={onRetry} />);
+    const button = screen.getByRole('button', { name: /retry/i });
+
+    await userEvent.setup().click(button);
+
+    // While the promise is pending, button shows "Retrying…" and is disabled
+    expect(button).toBeDisabled();
+    expect(button).toHaveTextContent(/retrying/i);
+
+    resolveRetry();
+    await waitFor(() => {
+      expect(button).not.toBeDisabled();
+    });
+  });
+
+  it('should_render_unparseable_label_when_event_type_is_null', () => {
+    render(
+      <DlqTable
+        events={[makeEvent({ eventType: null, transactionId: null })]}
+        loading={false}
+        onRetry={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/unparseable/i)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## What this PR does
Closes #23 

Adds the admin operations panel at /admin, gated behind ROLE_ADMIN.
Three sections, all polling every 3 s in parallel: the DLQ viewer
with per-event retry buttons, a circuit-breaker status card for the
payment-gateway breaker, and a Recharts bar chart of transaction
status distribution from the admin-scoped transactions list.
ProtectedRoute is extended with an optional `requiredRole` prop -
USER visitors to /admin get redirected to /dashboard, no flash of
admin content.

## How to test

From `frontend/`:

1. `npm install` - no new deps; Recharts already in lockfile.
2. `npm run typecheck` - strict TS, zero errors.
3. `npm test` - Vitest runs the existing tests plus the new admin
   component tests (~26 tests total).
4. With backend + Redis + Kafka running:
   - Sign in as a USER → /dashboard. There's no "Admin panel" link.
     Manually navigating to /admin in the URL bar bounces you back
     to /dashboard (no flash of forbidden content).
   - Promote your user to ADMIN in the DB:
     `UPDATE users SET role = 'ADMIN' WHERE username = 'you';`
   - Sign out, sign back in (so the JWT carries the ADMIN claim).
   - Click "Admin panel". You should see:
     * Circuit breaker card showing CLOSED with current metrics
       (or "-" for the rates if no payment calls have been made yet).
     * Status distribution bar chart populated from existing tx data.
     * DLQ table - empty unless a consumer has crashed.
   - To populate the DLQ: temporarily break a consumer (or use the
     DlqIntegrationTest's always-fail consumer in dev). Within 3 s the
     row appears. Click Retry → row's resolvedAt fills in.

## Technical decisions

**Promise.allSettled for the parallel poll**: one of the three
admin endpoints could be slow or failing while the others are fine.
Promise.all would short-circuit on first failure; allSettled lets
each section show its own error banner without blanking the others.

**Recharts only on the admin panel**: the spec calls out Recharts
in Task 22 (Admin Panel), not Task 20 (Dashboard). Charts are useful
for operational/aggregate views, not for "my transactions". Keeping
the heavier viz library out of the user dashboard's bundle path is
a happy side-effect.

**ProtectedRoute extended, not duplicated**: a single guard with an
optional `requiredRole` keeps route gating in one place and removes
the temptation to write a near-identical `AdminRoute` component.

**Imperative refresh on retry, not optimistic update**: after a
successful retry, refresh() runs immediately (instead of the next 3s
tick) so the resolved-row state updates without delay. Optimistic
updates were rejected - the backend may also persist resolution
metadata (resolvedBy = "admin-discard:unreadable-payload") that the
client can't predict.