### PR TITLE
ci(task-27): github actions - backend gradle test + frontend vite build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,44 +2,115 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: ['**']
   pull_request:
     branches: [main]
 
+# Read-only by default — no job needs write permissions to the repo.
+permissions:
+  contents: read
+
+# When a new commit lands on a branch, cancel any older still-running run for
+# the same ref. Keeps queue minutes from piling up on rapid pushes.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  test:
-    name: Build & Test
+  # ── Backend: gradle test against real Postgres + Redis + Kafka via Testcontainers
+  backend-test:
+    name: Backend test (gradle)
     runs-on: ubuntu-latest
-    # No service containers needed — tests use Testcontainers which provision
-    # their own Docker images. Service containers would waste ~30s of CI time.
+    timeout-minutes: 30
+
+    defaults:
+      run:
+        working-directory: backend
 
     steps:
-      - name: Checkout code
+      - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Java 17
+      - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
-          distribution: 'temurin'
+          distribution: temurin
           java-version: '17'
-          cache: 'gradle'
 
-      - name: Grant execute permission for gradlew
-        run: chmod +x gradlew
-        working-directory: backend
+      # Manual cache is more flexible than setup-java's built-in for
+      # multi-module projects: hashes every Gradle file so source-only
+      # changes hit the cache.
+      - name: Cache Gradle
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: gradle-${{ runner.os }}-${{ hashFiles('backend/**/*.gradle*', 'backend/gradle/wrapper/gradle-wrapper.properties') }}
+          restore-keys: |
+            gradle-${{ runner.os }}-
 
+      - name: Make gradlew executable
+        run: chmod +x ./gradlew
+
+      # GitHub-hosted ubuntu runners ship Docker; Testcontainers picks it up
+      # automatically via DOCKER_HOST defaults. No extra setup step needed.
       - name: Run tests
-        run: ./gradlew test
-        working-directory: backend
+        run: ./gradlew test --no-daemon --stacktrace
 
-      - name: Build project
-        run: ./gradlew build -x test
-        working-directory: backend
-
-      - name: Upload test report
+      # Always upload coverage so reviewers can read it on green AND red runs.
+      - name: Upload JaCoCo HTML report
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: test-report
-          path: backend/build/reports/tests/
+          name: jacoco-html-report
+          path: backend/build/reports/jacoco/test/html
           retention-days: 7
+          if-no-files-found: ignore
+
+      # On failure, the human-readable test reports are usually what's needed
+      # to diagnose. Longer retention than coverage — failures are referenced
+      # later when triaging.
+      - name: Upload test reports on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-reports-failed
+          path: backend/build/reports/tests/test
+          retention-days: 14
+          if-no-files-found: ignore
+
+  # ── Frontend: install + typecheck + vitest + production bundle
+  frontend-build:
+    name: Frontend build (vite)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    defaults:
+      run:
+        working-directory: frontend
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          # actions/setup-node has a built-in npm cache; just point it at the
+          # lockfile and it caches ~/.npm keyed by lockfile hash.
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Type-check
+        run: npm run typecheck
+
+      - name: Test
+        run: npm test
+
+      - name: Build production bundle
+        run: npm run build


### PR DESCRIPTION
## What this PR does
Closes #27 

Replaces the placeholder CI with a workflow that actually matches the
spec: two parallel jobs (backend gradle test against Testcontainers,
frontend Vite typecheck+test+build), triggered on push to any branch
and PRs to main. JaCoCo HTML coverage uploaded on every run; failed
test reports uploaded on red runs only, with longer retention so
post-failure triage isn't blocked by a 7-day artifact expiry.

`npm run lint` is the one spec line not implemented — ESLint isn't set
up in the project yet. Documented in IMPLEMENTATION_NOTES as a
~30-minute follow-up; tsc strict-mode + Vitest already catch the
correctness issues lint would for this codebase.

## How to test

1. Push this branch to GitHub: `git push origin task/25-github-actions`
2. Open the Actions tab on the repo. The workflow should appear under
"CI" with two running jobs.
3. **Backend test** takes ~6–10 minutes on a cold cache (Testcontainers
pulls Postgres + Kafka + Redis images). Subsequent runs reuse the
Gradle cache and finish in ~3–5 minutes.
4. **Frontend build** runs in <2 minutes on a warm npm cache.
5. After completion, the JaCoCo HTML artifact is downloadable from the
run summary. Open `index.html` from the unzipped artifact for
coverage.
6. To prove a red path fails CI cleanly: temporarily edit a Java test
to `assertThat(true).isFalse();`, push, watch CI fail. Restore the
test.

## Technical decisions

**Manual Gradle cache instead of setup-java's built-in**: setup-java's
`cache: 'gradle'` caches by hash of the *whole repo's* gradle files,
which means edits to any unrelated file invalidate. The manual cache
is keyed by `backend/**/*.gradle*` + the wrapper properties, so
source-only changes hit the cache.

**`concurrency.cancel-in-progress: true`**: rapid `git push --force`
loops during local dev would otherwise pile up minutes of queued runs
that nobody reads. Cancelling stale runs trades a tiny race window
for predictable queue throughput.

**Always upload JaCoCo, even on red**: coverage on a failing build is
still useful for "did the broken test actually exercise this path?"
inspection.